### PR TITLE
Fix issues found by address sanitizer

### DIFF
--- a/include/llvm-dialects/Dialect/Dialect.h
+++ b/include/llvm-dialects/Dialect/Dialect.h
@@ -91,6 +91,17 @@ class DialectContext final : private llvm::TrailingObjects<DialectContext, Diale
 public:
   ~DialectContext();
 
+  void operator delete(void *ctx);
+  
+  // Placement deletes are called if the constructor throws (shouldn't happen,
+  // but let's be thorough).
+  void operator delete(void *ctx, unsigned) {
+    DialectContext::operator delete(ctx);
+  }
+  void operator delete(void *ctx, unsigned, unsigned) {
+    DialectContext::operator delete(ctx);
+  }
+
   /// Get the DialectContext associated to the given LLVM context. This fails if no dialect context
   /// was created for the LLVM context.
   static DialectContext& get(llvm::LLVMContext& context);

--- a/lib/Dialect/Dialect.cpp
+++ b/lib/Dialect/Dialect.cpp
@@ -67,6 +67,8 @@ DialectContext::~DialectContext() {
     delete dialectArray[i]; // may be nullptr
 }
 
+void DialectContext::operator delete(void *ctx) { free(ctx); }
+
 std::unique_ptr<DialectContext> DialectContext::make(LLVMContext& context,
                                                      ArrayRef<DialectDescriptor> dialects) {
   unsigned dialectArraySize = 0;

--- a/lib/TableGen/GenDialect.cpp
+++ b/lib/TableGen/GenDialect.cpp
@@ -80,6 +80,8 @@ public:
     BaseCPred_Last = SameTypes,
   };
 
+  virtual ~Constraint() = default;
+
   virtual void init(DialectsContext* context, Record* record) {
     m_record = record;
     m_builderArgumentFilter = record->getValueAsString("builderArgumentFilter");
@@ -336,6 +338,8 @@ public:
     Logic_Last = Not,
     Apply,
   };
+
+  virtual ~PredicateExpr() = default;
 
   Kind getKind() const {return m_kind;}
 


### PR DESCRIPTION
All of these are fairly straightforward:

- Class hierarchies need a virtual destructor if we're going to use them with std::unique_ptr (as we're doing).
- A class with trailing objects uses a custom allocation, so we need to make sure it receives the corresponding custom deallocation treatment.