### PR TITLE
Export llvm-dialects's include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ else()
     target_link_libraries(llvm-dialects-tblgen PRIVATE llvm_dialects_tablegen ${llvm_libs})
 endif()
 
+target_include_directories(llvm_dialects PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 target_sources(llvm_dialects PRIVATE
     lib/Dialect/Builder.cpp
     lib/Dialect/Dialect.cpp


### PR DESCRIPTION
... for client projects to be able to access it without having to explicitly add it to their own target_include_directories.