### PR TITLE
Add .clang-format and formatting / typos GitHub workflows

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,0 +1,33 @@
+name: clang-format check
+on: [pull_request]
+
+jobs:
+  clang-format-check:
+    name: clang-format
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: Setup environment
+        run: |
+          sudo apt-get install -yqq clang-format-11
+      - name: Checkout llvm-dialects
+        uses: actions/checkout@v2
+      - name: Run clang-format
+        run: |
+          git diff ${{ github.base_ref }} -U0 --no-color -- '**/*.cpp' '**/*.cc' '**/*.h' '**/*.hh' \
+            | clang-format-diff-11 -p1 >not-formatted.diff 2>&1
+      - name: Check formatting
+        run: |
+          if ! grep -q '[^[:space:]]' not-formatted.diff ; then
+            echo "Code formatted. Success."
+          else
+            echo "Code not formatted."
+            echo "Please run clang-format-diff on your changes and push again:"
+            echo "    git diff ${{ github.base_ref }} -U0 --no-color | clang-format-diff -p1 -i"
+            echo ""
+            echo "Tip: you can disable clang-format checks: https://clang.llvm.org/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code"
+            echo ""
+            echo "Diff:"
+            cat not-formatted.diff
+            echo ""
+            exit 3
+          fi

--- a/.github/workflows/check-typos.yml
+++ b/.github/workflows/check-typos.yml
@@ -1,0 +1,21 @@
+name: Spell Check
+on: [pull_request]
+
+jobs:
+  run:
+    name: typos
+    runs-on: "ubuntu-20.04"
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Check spelling
+      uses: crate-ci/typos@v1.11.1
+
+    - name: Help
+      if: always()
+      run: |
+        echo 'To run the check locally, install typos from https://github.com/crate-ci/typos and run `typos` in the repository.'
+        echo 'Run `typos -w` to automatically correct spelling mistakes.'
+        echo
+        echo 'Please add false positives to .typos.toml'

--- a/lib/TableGen/GenDialect.cpp
+++ b/lib/TableGen/GenDialect.cpp
@@ -915,7 +915,7 @@ std::unique_ptr<PredicateExpr> DialectsContext::parsePredicateExpr(DagInit *dag)
 
     if (!argName) {
       report_fatal_error(
-          Twine("Predicate appliation has missing argument name: ")
+          Twine("Predicate application has missing argument name: ")
               + dag->getAsString());
     }
 


### PR DESCRIPTION
Use the LLVM style unmodified, so that exchanging code between upstream will be less tedious.

We currently *don't* follow that style. I'm inclined to doing a mass-format soon, though.