### PR TITLE
Further tweak the includes in the public interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,8 @@ else()
 endif()
 
 target_include_directories(llvm_dialects PUBLIC
-    include)
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
 
 target_include_directories(llvm_dialects PRIVATE
     ${LLVM_INCLUDE_DIRS})


### PR DESCRIPTION
This avoids an error of the form "Target "llvm-dialects" INTERFACE_INCLUDE_DIRECTORIES property contains path (...) which is prefixed in the source directory."