### PR TITLE
Fix warnings about lack of ArrayRef deduction guides

### DIFF
--- a/lib/TableGen/Format.cpp
+++ b/lib/TableGen/Format.cpp
@@ -208,7 +208,7 @@ void FmtObjectBase::format(raw_ostream &s) const {
         s << repl.spec << kMarkerForNoSubst;
         continue;
       }
-      auto range = ArrayRef(adapters);
+      auto range = ArrayRef<llvm::detail::format_adapter *>(adapters);
       range = range.drop_front(repl.index);
       if (repl.end != FmtReplacement::kUnset)
         range = range.drop_back(adapters.size() - repl.end);

--- a/lib/TableGen/GenDialect.cpp
+++ b/lib/TableGen/GenDialect.cpp
@@ -42,7 +42,9 @@ class SymbolTable {
   std::unordered_set<std::string> m_names;
 
 public:
-  std::string chooseName(StringRef name) { return chooseName(ArrayRef(name)); }
+  std::string chooseName(StringRef name) {
+    return chooseName(ArrayRef<StringRef>(name));
+  }
 
   std::string chooseName(ArrayRef<StringRef> names) {
     for (StringRef name : names) {


### PR DESCRIPTION
Fix warnings when built against an older LLVM that does not have deduction guides for ArrayRef:

warning: 'ArrayRef' may not intend to support class template argument deduction [-Wctad-maybe-unsupported]