### PR TITLE
Add -no-memory-effects option

### DIFF
--- a/include/llvm-dialects/TableGen/Traits.h
+++ b/include/llvm-dialects/TableGen/Traits.h
@@ -72,4 +72,6 @@ public:
   }
 };
 
+bool noMemoryEffects();
+
 } // namespace llvm_dialects

--- a/lib/TableGen/GenDialect.cpp
+++ b/lib/TableGen/GenDialect.cpp
@@ -319,7 +319,15 @@ void llvm_dialects::genDialectDefs(raw_ostream& out, RecordKeeper& records) {
 #include "llvm-dialects/Dialect/OpDescription.h"
 #include "llvm-dialects/Dialect/Utils.h"
 #include "llvm/IR/InstrTypes.h"
+)";
+
+  if (!noMemoryEffects()) {
+    out << R"(
 #include "llvm/Support/ModRef.h"
+)";
+  }
+
+  out << R"(
 #endif // GET_INCLUDES
 
 #ifdef GET_DIALECT_DEFS

--- a/test/example/CMakeLists.txt
+++ b/test/example/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 ### Example application
 
-add_executable(llvm-dialects-example
+add_executable(llvm-dialects-example EXCLUDE_FROM_ALL
     ExampleDialect.cpp
     ExampleMain.cpp)
 llvm_update_compile_flags(llvm-dialects-example)

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -7,7 +7,9 @@
 #include "llvm-dialects/Dialect/OpDescription.h"
 #include "llvm-dialects/Dialect/Utils.h"
 #include "llvm/IR/InstrTypes.h"
+
 #include "llvm/Support/ModRef.h"
+
 #endif // GET_INCLUDES
 
 #ifdef GET_DIALECT_DEFS


### PR DESCRIPTION
This is a temporary workaround for compatibility with not-quite-recent versions of LLVM.