### PR TITLE
Add a verifier and verifier pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ target_include_directories(llvm_dialects PRIVATE
 
 target_sources(llvm_dialects PRIVATE
     lib/Dialect/Builder.cpp
+    lib/Dialect/ContextExtension.cpp
     lib/Dialect/Dialect.cpp
     lib/Dialect/OpDescription.cpp
     lib/Dialect/Utils.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ target_sources(llvm_dialects PRIVATE
     lib/Dialect/Dialect.cpp
     lib/Dialect/OpDescription.cpp
     lib/Dialect/Utils.cpp
+    lib/Dialect/Verifier.cpp
     lib/Dialect/Visitor.cpp)
 
 target_include_directories(llvm_dialects_tablegen PRIVATE

--- a/include/llvm-dialects/Dialect/ContextExtension.h
+++ b/include/llvm-dialects/Dialect/ContextExtension.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "llvm/ADT/ArrayRef.h"
+
+namespace llvm {
+class LLVMContext;
+} // namespace llvm
+
+namespace llvm_dialects {
+
+class ContextExtensionBase;
+class DialectContext;
+
+namespace detail {
+
+class ContextExtensionKey {
+  unsigned m_index;
+
+  virtual void anchor();
+
+public:
+  ContextExtensionKey();
+  ~ContextExtensionKey();
+
+  unsigned getIndex() const { return m_index; }
+
+  ContextExtensionBase &get(llvm::LLVMContext &context);
+  ContextExtensionBase &get(DialectContext &context);
+
+  static llvm::ArrayRef<ContextExtensionKey *> getKeys();
+
+protected:
+  virtual std::unique_ptr<ContextExtensionBase>
+  create(llvm::LLVMContext &context) = 0;
+};
+
+} // namespace detail
+
+class ContextExtensionBase {
+  virtual void anchor();
+
+public:
+  virtual ~ContextExtensionBase() = default;
+};
+
+/// CRTP base class for extended data that can be attached to LLVMContexts.
+///
+/// In fact, extended data is currently attached to the DialectContext, but
+/// conceptually this feature is independent of dialect support.
+///
+/// Extended data types must derive from this template base using the following
+/// pattern:
+///
+///   class MyExtension : public ContextExtensionImpl<MyExtension> {
+///   public:
+///     MyExtension(llvm::LLVMContext &context);
+///
+///     static Key theKey; // instantiate this in a source file
+///   };
+///
+/// Extension data can be retrieved using the static method call
+/// MyExtension::get(llvmContext).
+///
+/// The extension data is allocated and constructed the first time it is
+/// requested. The destructor is called when the DialectContext is destroyed.
+///
+/// Note that all context extension types must be present (their keys having
+/// registered themselves) _before_ creating the DialectContext with which they
+/// are going to be used (this restriction only really matters when dynamic
+/// linking is used: it is not possible to dynamically load an extension after
+/// a context is created, and then use the extension with that context).
+template <typename ContextExtensionT>
+class ContextExtensionImpl : public ContextExtensionBase {
+public:
+  class Key : public detail::ContextExtensionKey {
+  protected:
+    std::unique_ptr<ContextExtensionBase>
+    create(llvm::LLVMContext &context) override {
+      return std::make_unique<ContextExtensionT>(context);
+    }
+  };
+
+  static ContextExtensionT &get(llvm::LLVMContext &context) {
+    // Assign to an explicitly typed variable for type checking at template
+    // instantiation time.
+    Key &key = ContextExtensionT::theKey;
+    return static_cast<ContextExtensionT &>(key.get(context));
+  }
+
+  static ContextExtensionT &get(DialectContext &context) {
+    // Assign to an explicitly typed variable for type checking at template
+    // instantiation time.
+    Key &key = ContextExtensionT::theKey;
+    return static_cast<ContextExtensionT &>(key.get(context));
+  }
+};
+
+} // namespace llvm_dialects

--- a/include/llvm-dialects/Dialect/Verifier.h
+++ b/include/llvm-dialects/Dialect/Verifier.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "llvm-dialects/Dialect/Dialect.h"
+#include "llvm-dialects/Dialect/Visitor.h"
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+class Module;
+class raw_ostream;
+} // namespace llvm
+
+namespace llvm_dialects {
+
+class VerifierState {
+public:
+  VerifierState(llvm::raw_ostream &out) : m_out(out) {}
+
+  bool hasError() const { return m_error; }
+  llvm::raw_ostream &out() { return m_out; }
+  void setError() { m_error = true; }
+
+private:
+  llvm::raw_ostream &m_out;
+  bool m_error = false;
+};
+
+using VerifierExtension = void(VisitorBuilder<VerifierState> &);
+DialectExtensionPoint<VerifierExtension> &getVerifierExtensionPoint();
+
+bool verify(llvm::Module &module, llvm::raw_ostream &out);
+
+class VerifyModulePass : public llvm::PassInfoMixin<VerifyModulePass> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &module,
+                              llvm::ModuleAnalysisManager &analysisManager);
+};
+
+} // namespace llvm_dialects

--- a/lib/Dialect/ContextExtension.cpp
+++ b/lib/Dialect/ContextExtension.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "llvm-dialects/Dialect/ContextExtension.h"
+
+#include "llvm-dialects/Dialect/Dialect.h"
+
+using namespace llvm;
+using namespace llvm_dialects;
+using namespace llvm_dialects::detail;
+
+namespace {
+
+SmallVectorImpl<ContextExtensionKey *> &getContextExtensionKeys() {
+  static SmallVector<ContextExtensionKey *> keys;
+  return keys;
+}
+
+} // anonymous namespace
+
+void ContextExtensionKey::anchor() {}
+
+ContextExtensionKey::ContextExtensionKey() {
+  auto &keys = getContextExtensionKeys();
+
+  for (m_index = 0; m_index < keys.size(); ++m_index) {
+    if (!keys[m_index])
+      break;
+  }
+  if (m_index < keys.size()) {
+    keys[m_index] = this;
+  } else {
+    keys.push_back(this);
+  }
+}
+
+ContextExtensionKey::~ContextExtensionKey() {
+  auto &keys = getContextExtensionKeys();
+  keys[m_index] = nullptr;
+  m_index = std::numeric_limits<unsigned>::max();
+}
+
+ContextExtensionBase &ContextExtensionKey::get(llvm::LLVMContext &context) {
+  return get(DialectContext::get(context));
+}
+
+ContextExtensionBase &ContextExtensionKey::get(DialectContext &context) {
+  auto &slot = context.getExtensionSlot(m_index);
+  if (!slot)
+    slot = create(context.getContext());
+  return *slot;
+}
+
+ArrayRef<ContextExtensionKey *> ContextExtensionKey::getKeys() {
+  return getContextExtensionKeys();
+}
+
+void ContextExtensionBase::anchor() {}

--- a/lib/Dialect/Dialect.cpp
+++ b/lib/Dialect/Dialect.cpp
@@ -233,6 +233,18 @@ DialectContext& DialectContext::get(LLVMContext& context) {
   return *CurrentContextCache::get(&context);
 }
 
+void DialectExtensionPointBase::add(unsigned index, const void *extension) {
+  if (index >= m_extensions.size())
+    m_extensions.resize(index + 1, nullptr);
+  assert(m_extensions[index] == nullptr);
+  m_extensions[index] = extension;
+}
+
+void DialectExtensionPointBase::clear(unsigned index) {
+  assert(index < m_extensions.size() && m_extensions[index] != nullptr);
+  m_extensions[index] = nullptr;
+}
+
 bool llvm_dialects::detail::isSimpleOperationDecl(const Function *fn,
                                                   StringRef name) {
   return fn->getName() == name;

--- a/lib/Dialect/Verifier.cpp
+++ b/lib/Dialect/Verifier.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "llvm-dialects/Dialect/Verifier.h"
+
+#include "llvm-dialects/Dialect/ContextExtension.h"
+
+using namespace llvm;
+using namespace llvm_dialects;
+
+namespace {
+
+struct VerifierContextExtension
+    : public ContextExtensionImpl<VerifierContextExtension> {
+  static Key theKey;
+
+  VerifierContextExtension(LLVMContext &context) : visitor(build(context)) {}
+
+  static Visitor<VerifierState> build(LLVMContext &context) {
+    VisitorBuilder<VerifierState> builder;
+    auto extensions = getVerifierExtensionPoint().getExtensions(context);
+    for (VerifierExtension *extension : extensions)
+      (*extension)(builder);
+    return builder.build();
+  }
+
+  Visitor<VerifierState> visitor;
+};
+
+VerifierContextExtension::Key VerifierContextExtension::theKey;
+
+} // anonymous namespace
+
+DialectExtensionPoint<VerifierExtension> &
+llvm_dialects::getVerifierExtensionPoint() {
+  static DialectExtensionPoint<VerifierExtension> point;
+  return point;
+}
+
+bool llvm_dialects::verify(Module &module, raw_ostream &out) {
+  const auto &extension = VerifierContextExtension::get(module.getContext());
+
+  std::string outstr;
+  llvm::raw_string_ostream outstream{outstr};
+  bool ok = true;
+
+  for (Function &fn : module.functions()) {
+    for (BasicBlock &bb : fn) {
+      for (Instruction &inst : bb) {
+        VerifierState state{outstream};
+        extension.visitor.visit(state, inst);
+        if (state.hasError()) {
+          out << "Verifier error in: " << inst << '\n' << outstr;
+          ok = false;
+        }
+        assert(outstr.empty() == !state.hasError());
+        outstr.clear();
+      }
+    }
+  }
+  return ok;
+}
+
+PreservedAnalyses
+VerifyModulePass::run(Module &module, ModuleAnalysisManager &analysisManager) {
+  if (!verify(module, llvm::errs()))
+    report_fatal_error("llvm_dialects IR verification failed");
+  return PreservedAnalyses::all();
+}

--- a/lib/Dialect/Visitor.cpp
+++ b/lib/Dialect/Visitor.cpp
@@ -37,15 +37,18 @@ VisitorBase::VisitorBase(VisitorBuilderBase builder)
     : m_strategy(builder.m_strategy), m_cases(std::move(builder.m_cases)) {
 }
 
+void VisitorBase::visit(void *payload, Instruction &inst) const {
+  for (const auto &[desc, extra, callback] : m_cases) {
+    if (desc->matchInstruction(inst))
+      callback(extra, payload, &inst);
+  }
+}
+
 void VisitorBase::visit(void *payload, Function &fn) const {
   if (m_strategy == VisitorStrategy::ByInstruction) {
     for (BasicBlock &bb : fn) {
-      for (Instruction &inst : bb) {
-        for (const auto &[desc, extra, callback] : m_cases) {
-          if (desc->matchInstruction(inst))
-            callback(extra, payload, &inst);
-        }
-      }
+      for (Instruction &inst : bb)
+        visit(payload, inst);
     }
     return;
   }

--- a/test/example/generated/.clang-format
+++ b/test/example/generated/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -6,6 +6,8 @@
 #include "llvm-dialects/Dialect/Builder.h"
 #include "llvm-dialects/Dialect/OpDescription.h"
 #include "llvm-dialects/Dialect/Utils.h"
+#include "llvm-dialects/Dialect/Verifier.h"
+#include "llvm-dialects/Dialect/Visitor.h"
 #include "llvm/IR/InstrTypes.h"
 
 #include "llvm/Support/ModRef.h"
@@ -25,6 +27,63 @@ namespace xd {
     }
 
     ::llvm_dialects::Dialect* ExampleDialect::make(::llvm::LLVMContext& context) {
+      
+      auto verifierExtension = [](::llvm_dialects::VisitorBuilder<::llvm_dialects::VerifierState> &builder) {
+    
+        builder.add<Add32Op>([](::llvm_dialects::VerifierState &state, Add32Op &op) {
+          if (!op.verifier(state.out()))
+            state.setError();
+        });
+      
+        builder.add<CombineOp>([](::llvm_dialects::VerifierState &state, CombineOp &op) {
+          if (!op.verifier(state.out()))
+            state.setError();
+        });
+      
+        builder.add<ExtractElementOp>([](::llvm_dialects::VerifierState &state, ExtractElementOp &op) {
+          if (!op.verifier(state.out()))
+            state.setError();
+        });
+      
+        builder.add<FromFixedVectorOp>([](::llvm_dialects::VerifierState &state, FromFixedVectorOp &op) {
+          if (!op.verifier(state.out()))
+            state.setError();
+        });
+      
+        builder.add<IExtOp>([](::llvm_dialects::VerifierState &state, IExtOp &op) {
+          if (!op.verifier(state.out()))
+            state.setError();
+        });
+      
+        builder.add<ITruncOp>([](::llvm_dialects::VerifierState &state, ITruncOp &op) {
+          if (!op.verifier(state.out()))
+            state.setError();
+        });
+      
+        builder.add<InsertElementOp>([](::llvm_dialects::VerifierState &state, InsertElementOp &op) {
+          if (!op.verifier(state.out()))
+            state.setError();
+        });
+      
+        builder.add<ReadOp>([](::llvm_dialects::VerifierState &state, ReadOp &op) {
+          if (!op.verifier(state.out()))
+            state.setError();
+        });
+      
+        builder.add<SizeOfOp>([](::llvm_dialects::VerifierState &state, SizeOfOp &op) {
+          if (!op.verifier(state.out()))
+            state.setError();
+        });
+      
+        builder.add<WriteOp>([](::llvm_dialects::VerifierState &state, WriteOp &op) {
+          if (!op.verifier(state.out()))
+            state.setError();
+        });
+      
+      };
+      static ::llvm_dialects::DialectExtensionRegistration<::llvm_dialects::VerifierExtension, ExampleDialect>
+          verifierExtensionRegistration(::llvm_dialects::getVerifierExtensionPoint(), verifierExtension);
+    
       return new ExampleDialect(context);
     }
 

--- a/test/example/generated/ExampleDialect.h.inc
+++ b/test/example/generated/ExampleDialect.h.inc
@@ -28,6 +28,7 @@ namespace xd {
 
       void anchor() override;
 
+    public:
       static Key& getKey();
 
     private:

--- a/test/example/verifier-basic.ll
+++ b/test/example/verifier-basic.ll
@@ -1,0 +1,33 @@
+; RUN: not llvm-dialects-example -verify %s | FileCheck --check-prefixes=CHECK %s
+
+define void @test1() {
+entry:
+; CHECK-LABEL: Verifier error in: %sizeof1 =
+; CHECK:  unexpected value of $result:
+; CHECK:    expected:  i64
+; CHECK:    actual:    i32
+  %sizeof1 = call i32 (...) @xd.sizeof(<10 x i32> poison)
+
+; CHECK-LABEL: Verifier error in:   %trunc1 =
+; CHECK:  failed check for (le ?:$result_width, ?:$source_width)
+; CHECK:  with $result_width = 64
+; CHECK:  with $source_width = 32
+  %trunc1 = call i64 (...) @xd.itrunc.i64(i32 %sizeof1)
+
+; CHECK-LABEL: Verifier error in:   %fromfixedvector1 =
+; CHECK:  unexpected value of $scalar_type:
+; CHECK:    expected:  i32
+; CHECK:    actual:    i64
+  %fromfixedvector1 = call target("xd.vector", i32, 2) (...) @xd.fromfixedvector.txd.vector_i32_2t(<2 x i64> poison)
+
+; CHECK-LABEL: Verifier error in:   %fromfixedvector2 =
+; CHECK:  unexpected value of $num_elements:
+; CHECK:    expected:  2
+; CHECK:    actual:    4
+  %fromfixedvector2 = call target("xd.vector", i32, 2) (...) @xd.fromfixedvector.txd.vector_i32_2t(<4 x i32> poison)
+  ret void
+}
+
+declare i32 @xd.sizeof(...)
+declare i64 @xd.itrunc.i64(...)
+declare target("xd.vector", i32, 2) @xd.fromfixedvector.txd.vector_i32_2t(...)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -22,7 +22,7 @@ config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files. This is overridden
 # by individual lit.local.cfg files in the test subdirectories.
-config.suffixes = ['.test', '.td']
+config.suffixes = ['.test', '.td', '.ll']
 
 # excludes: A list of directories to exclude from the testsuite. The 'generated'
 # subdirectories contain auxiliary inputs for various tests in their parent


### PR DESCRIPTION
This PR is split into a bunch of commits which first add some generic "extension" facilities and then build the verifier on top of it. The verifier pass currently checks precisely the constraints on operations that are also checked by the builder methods.