### PR TITLE
Fix some issues with OpClass

### DIFF
--- a/example/ExampleDialect.td
+++ b/example/ExampleDialect.td
@@ -167,3 +167,29 @@ def IExtOp : ExampleOp<"iext", [Memory<[]>, NoUnwind, WillReturn]> {
     position.
   }];
 }
+
+def StreamReduceOp : OpClass<ExampleDialect> {
+  let arguments = (ins Ptr:$ptr, I64:$count, value:$initial);
+
+  let summary = "family of operations that reduce some array in memory";
+  let description = [{
+    Illustrate the use of the OpClass feature.
+  }];
+}
+
+class StreamReduceTemplate<string op>
+    : ExampleOp<"stream." # op, [Memory<[(read)]>, NoUnwind, WillReturn]> {
+  let superclass = StreamReduceOp;
+
+  let results = (outs (eq $initial):$result);
+  let arguments = (ins superclass);
+
+  let summary = "perform the " # op # " operation streaming from memory";
+  let description = [{
+    Illustrate the use of the OpClass feature.
+  }];
+}
+
+def StreamAddOp : StreamReduceTemplate<"add">;
+def StreamMaxOp : StreamReduceTemplate<"max">;
+def StreamMinOp : StreamReduceTemplate<"min">;

--- a/example/ExampleMain.cpp
+++ b/example/ExampleMain.cpp
@@ -81,6 +81,10 @@ void createFunctionExample(Module &module, const Twine &name) {
   Value *y6 = b.create<xd::InsertElementOp>(y5, y2, b.getInt32(1));
   b.create<xd::WriteOp>(y6);
 
+  Value *p1 = b.create<xd::ReadOp>(b.getPtrTy(0));
+  Value *p2 = b.create<xd::StreamAddOp>(p1, b.getInt64(14), b.getInt8(0));
+  b.create<xd::WriteOp>(p2);
+
   b.CreateRetVoid();
 }
 

--- a/lib/TableGen/GenDialect.cpp
+++ b/lib/TableGen/GenDialect.cpp
@@ -148,7 +148,7 @@ class Builder;
     )", &fmt, opClass->superclass ? opClass->superclass->name : "::llvm::CallInst");
 
     for (const auto& arg : opClass->arguments) {
-      out << tgfmt("$0 get$1();\n", &fmt, arg.type->getCppType(),
+      out << tgfmt("$0 get$1();\n", &fmt, arg.type->getBuilderCppType(),
                    convertToCamelFromSnakeCase(arg.name, true));
     }
 
@@ -369,7 +369,9 @@ void llvm_dialects::genDialectDefs(raw_ostream& out, RecordKeeper& records) {
         $0 $_op::get$1() {
           return $2;
         }
-      )", &fmt, arg.type->getCppType(), convertToCamelFromSnakeCase(arg.name, true), value);
+      )",
+                   &fmt, arg.type->getBuilderCppType(),
+                   convertToCamelFromSnakeCase(arg.name, true), value);
     }
 
     out << '\n';

--- a/lib/TableGen/Operations.cpp
+++ b/lib/TableGen/Operations.cpp
@@ -131,7 +131,7 @@ bool Operation::parse(raw_ostream &errs, GenDialectsContext *context,
 
   EvaluationPlanner evaluation(op->m_system);
 
-  for (const auto &arg : op->arguments) {
+  for (const auto &arg : op->getFullArguments()) {
     auto variable = op->m_scope.getVariable(arg.name);
     ConstraintSystem singletonSystem{*context, op->m_scope};
     if (!singletonSystem.addConstraint(errs, arg.constraint, variable))

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -75,6 +75,21 @@ namespace xd {
             state.setError();
         });
       
+        builder.add<StreamAddOp>([](::llvm_dialects::VerifierState &state, StreamAddOp &op) {
+          if (!op.verifier(state.out()))
+            state.setError();
+        });
+      
+        builder.add<StreamMaxOp>([](::llvm_dialects::VerifierState &state, StreamMaxOp &op) {
+          if (!op.verifier(state.out()))
+            state.setError();
+        });
+      
+        builder.add<StreamMinOp>([](::llvm_dialects::VerifierState &state, StreamMinOp &op) {
+          if (!op.verifier(state.out()))
+            state.setError();
+        });
+      
         builder.add<WriteOp>([](::llvm_dialects::VerifierState &state, WriteOp &op) {
           if (!op.verifier(state.out()))
             state.setError();
@@ -105,8 +120,15 @@ m_attributeLists[1] = ::llvm::AttributeList::get(context, ::llvm::AttributeList:
 {
   ::llvm::AttrBuilder attrBuilder{context};
 attrBuilder.addAttribute(::llvm::Attribute::NoUnwind);
-attrBuilder.addMemoryAttr(::llvm::MemoryEffects(::llvm::MemoryEffects::Location::InaccessibleMem, ::llvm::ModRefInfo::ModRef));
+attrBuilder.addAttribute(::llvm::Attribute::WillReturn);
+attrBuilder.addMemoryAttr(::llvm::MemoryEffects(::llvm::ModRefInfo::Ref));
 m_attributeLists[2] = ::llvm::AttributeList::get(context, ::llvm::AttributeList::FunctionIndex, attrBuilder);
+}
+{
+  ::llvm::AttrBuilder attrBuilder{context};
+attrBuilder.addAttribute(::llvm::Attribute::NoUnwind);
+attrBuilder.addMemoryAttr(::llvm::MemoryEffects(::llvm::MemoryEffects::Location::InaccessibleMem, ::llvm::ModRefInfo::ModRef));
+m_attributeLists[3] = ::llvm::AttributeList::get(context, ::llvm::AttributeList::FunctionIndex, attrBuilder);
 }
 }
 
@@ -164,6 +186,31 @@ auto numElements = getNumElements();
 return true;
 }
 
+
+      bool StreamReduceOp::classof(const ::llvm::CallInst* i) {
+    
+        if (StreamAddOp::classof(i)) return true;
+      
+        if (StreamMaxOp::classof(i)) return true;
+      
+        if (StreamMinOp::classof(i)) return true;
+      
+        return false;
+      }
+
+    
+        ::llvm::Value * StreamReduceOp::getPtr() {
+          return getArgOperand(0);
+        }
+      
+        ::llvm::Value * StreamReduceOp::getCount() {
+          return getArgOperand(1);
+        }
+      
+        ::llvm::Value * StreamReduceOp::getInitial() {
+          return getArgOperand(2);
+        }
+      
 
       const ::llvm::StringLiteral Add32Op::s_name{"xd.add32"};
 
@@ -755,7 +802,7 @@ index,
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(2);
+          = ExampleDialect::get(context).getAttributeList(3);
     
       std::string mangledName =
           ::llvm_dialects::getMangledName(s_name, {dataType});
@@ -842,6 +889,231 @@ index,
         }
       
 ::llvm::Value *SizeOfOp::getResult() {return this;}
+
+
+
+      const ::llvm::StringLiteral StreamAddOp::s_name{"xd.stream.add"};
+
+    StreamAddOp* StreamAddOp::create(llvm_dialects::Builder& b, ::llvm::Value * ptr, ::llvm::Value * count, ::llvm::Value * initial) {
+    ::llvm::LLVMContext& context = b.getContext();
+    ::llvm::Module& module = *b.GetInsertBlock()->getModule();
+  
+  
+      const ::llvm::AttributeList attrs
+          = ExampleDialect::get(context).getAttributeList(2);
+    
+      std::string mangledName =
+          ::llvm_dialects::getMangledName(s_name, {initial->getType()});
+    auto fnType = ::llvm::FunctionType::get(initial->getType(), true);
+
+    auto fn = module.getOrInsertFunction(mangledName, fnType, attrs);
+
+  ::llvm::Value* const args[] = {
+ptr,
+count,
+initial,
+
+      };
+
+      return ::llvm::cast<StreamAddOp>(b.CreateCall(fn, args));
+    }
+
+
+    bool StreamAddOp::verifier(::llvm::raw_ostream &errs) {
+      ::llvm::LLVMContext &context = getModule()->getContext();
+      (void)context;
+
+      using ::llvm_dialects::printable;
+
+      if (arg_size() != 3) {
+        errs << "  wrong number of arguments: " << arg_size()
+               << ", expected 3\n";
+        return false;
+      }
+  ::llvm::Type * const ptrType = getPtr()->getType();
+(void)ptrType;
+::llvm::Type * const countType = getCount()->getType();
+(void)countType;
+::llvm::Type * const initialType = getInitial()->getType();
+(void)initialType;
+::llvm::Type * const resultType = getResult()->getType();
+(void)resultType;
+
+        if (::llvm::PointerType::get(context, 0) != ptrType) {
+          errs << "  unexpected value of $ptr:\n";
+          errs << "    expected:  " << printable(::llvm::PointerType::get(context, 0)) << '\n';
+          errs << "    actual:    " << printable(ptrType) << '\n';
+          return false;
+        }
+      
+        if (::llvm::IntegerType::get(context, 64) != countType) {
+          errs << "  unexpected value of $count:\n";
+          errs << "    expected:  " << printable(::llvm::IntegerType::get(context, 64)) << '\n';
+          errs << "    actual:    " << printable(countType) << '\n';
+          return false;
+        }
+      
+        if (initialType != resultType) {
+          errs << "  unexpected value of $result:\n";
+          errs << "    expected:  " << printable(initialType) << '\n';
+          errs << "    actual:    " << printable(resultType) << '\n';
+          return false;
+        }
+        return true;
+}
+
+
+::llvm::Value *StreamAddOp::getResult() {return this;}
+
+
+
+      const ::llvm::StringLiteral StreamMaxOp::s_name{"xd.stream.max"};
+
+    StreamMaxOp* StreamMaxOp::create(llvm_dialects::Builder& b, ::llvm::Value * ptr, ::llvm::Value * count, ::llvm::Value * initial) {
+    ::llvm::LLVMContext& context = b.getContext();
+    ::llvm::Module& module = *b.GetInsertBlock()->getModule();
+  
+  
+      const ::llvm::AttributeList attrs
+          = ExampleDialect::get(context).getAttributeList(2);
+    
+      std::string mangledName =
+          ::llvm_dialects::getMangledName(s_name, {initial->getType()});
+    auto fnType = ::llvm::FunctionType::get(initial->getType(), true);
+
+    auto fn = module.getOrInsertFunction(mangledName, fnType, attrs);
+
+  ::llvm::Value* const args[] = {
+ptr,
+count,
+initial,
+
+      };
+
+      return ::llvm::cast<StreamMaxOp>(b.CreateCall(fn, args));
+    }
+
+
+    bool StreamMaxOp::verifier(::llvm::raw_ostream &errs) {
+      ::llvm::LLVMContext &context = getModule()->getContext();
+      (void)context;
+
+      using ::llvm_dialects::printable;
+
+      if (arg_size() != 3) {
+        errs << "  wrong number of arguments: " << arg_size()
+               << ", expected 3\n";
+        return false;
+      }
+  ::llvm::Type * const ptrType = getPtr()->getType();
+(void)ptrType;
+::llvm::Type * const countType = getCount()->getType();
+(void)countType;
+::llvm::Type * const initialType = getInitial()->getType();
+(void)initialType;
+::llvm::Type * const resultType = getResult()->getType();
+(void)resultType;
+
+        if (::llvm::PointerType::get(context, 0) != ptrType) {
+          errs << "  unexpected value of $ptr:\n";
+          errs << "    expected:  " << printable(::llvm::PointerType::get(context, 0)) << '\n';
+          errs << "    actual:    " << printable(ptrType) << '\n';
+          return false;
+        }
+      
+        if (::llvm::IntegerType::get(context, 64) != countType) {
+          errs << "  unexpected value of $count:\n";
+          errs << "    expected:  " << printable(::llvm::IntegerType::get(context, 64)) << '\n';
+          errs << "    actual:    " << printable(countType) << '\n';
+          return false;
+        }
+      
+        if (initialType != resultType) {
+          errs << "  unexpected value of $result:\n";
+          errs << "    expected:  " << printable(initialType) << '\n';
+          errs << "    actual:    " << printable(resultType) << '\n';
+          return false;
+        }
+        return true;
+}
+
+
+::llvm::Value *StreamMaxOp::getResult() {return this;}
+
+
+
+      const ::llvm::StringLiteral StreamMinOp::s_name{"xd.stream.min"};
+
+    StreamMinOp* StreamMinOp::create(llvm_dialects::Builder& b, ::llvm::Value * ptr, ::llvm::Value * count, ::llvm::Value * initial) {
+    ::llvm::LLVMContext& context = b.getContext();
+    ::llvm::Module& module = *b.GetInsertBlock()->getModule();
+  
+  
+      const ::llvm::AttributeList attrs
+          = ExampleDialect::get(context).getAttributeList(2);
+    
+      std::string mangledName =
+          ::llvm_dialects::getMangledName(s_name, {initial->getType()});
+    auto fnType = ::llvm::FunctionType::get(initial->getType(), true);
+
+    auto fn = module.getOrInsertFunction(mangledName, fnType, attrs);
+
+  ::llvm::Value* const args[] = {
+ptr,
+count,
+initial,
+
+      };
+
+      return ::llvm::cast<StreamMinOp>(b.CreateCall(fn, args));
+    }
+
+
+    bool StreamMinOp::verifier(::llvm::raw_ostream &errs) {
+      ::llvm::LLVMContext &context = getModule()->getContext();
+      (void)context;
+
+      using ::llvm_dialects::printable;
+
+      if (arg_size() != 3) {
+        errs << "  wrong number of arguments: " << arg_size()
+               << ", expected 3\n";
+        return false;
+      }
+  ::llvm::Type * const ptrType = getPtr()->getType();
+(void)ptrType;
+::llvm::Type * const countType = getCount()->getType();
+(void)countType;
+::llvm::Type * const initialType = getInitial()->getType();
+(void)initialType;
+::llvm::Type * const resultType = getResult()->getType();
+(void)resultType;
+
+        if (::llvm::PointerType::get(context, 0) != ptrType) {
+          errs << "  unexpected value of $ptr:\n";
+          errs << "    expected:  " << printable(::llvm::PointerType::get(context, 0)) << '\n';
+          errs << "    actual:    " << printable(ptrType) << '\n';
+          return false;
+        }
+      
+        if (::llvm::IntegerType::get(context, 64) != countType) {
+          errs << "  unexpected value of $count:\n";
+          errs << "    expected:  " << printable(::llvm::IntegerType::get(context, 64)) << '\n';
+          errs << "    actual:    " << printable(countType) << '\n';
+          return false;
+        }
+      
+        if (initialType != resultType) {
+          errs << "  unexpected value of $result:\n";
+          errs << "    expected:  " << printable(initialType) << '\n';
+          errs << "    actual:    " << printable(resultType) << '\n';
+          return false;
+        }
+        return true;
+}
+
+
+::llvm::Value *StreamMinOp::getResult() {return this;}
 
 
 
@@ -960,6 +1232,30 @@ data,
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::SizeOfOp>() {
         static const ::llvm_dialects::OpDescription desc{false, "xd.sizeof"};
+        return desc;
+      }
+
+    
+      template <>
+      const ::llvm_dialects::OpDescription &
+      ::llvm_dialects::OpDescription::get<xd::StreamAddOp>() {
+        static const ::llvm_dialects::OpDescription desc{true, "xd.stream.add"};
+        return desc;
+      }
+
+    
+      template <>
+      const ::llvm_dialects::OpDescription &
+      ::llvm_dialects::OpDescription::get<xd::StreamMaxOp>() {
+        static const ::llvm_dialects::OpDescription desc{true, "xd.stream.max"};
+        return desc;
+      }
+
+    
+      template <>
+      const ::llvm_dialects::OpDescription &
+      ::llvm_dialects::OpDescription::get<xd::StreamMinOp>() {
+        static const ::llvm_dialects::OpDescription desc{true, "xd.stream.min"};
         return desc;
       }
 

--- a/test/example/generated/ExampleDialect.h.inc
+++ b/test/example/generated/ExampleDialect.h.inc
@@ -42,7 +42,7 @@ namespace xd {
         }
 
       private:
-        ::std::array<::llvm::AttributeList, 3> m_attributeLists;
+        ::std::array<::llvm::AttributeList, 4> m_attributeLists;
     };
 
     class XdVectorType : public ::llvm::TargetExtType {
@@ -66,6 +66,19 @@ uint32_t getNumElements() const;
 };
 
 
+      class StreamReduceOp : public ::llvm::CallInst {
+      public:
+        static bool classof(const ::llvm::CallInst* i);
+        static bool classof(const ::llvm::Value* v) {
+          return ::llvm::isa<::llvm::CallInst>(v) &&
+                 classof(::llvm::cast<::llvm::CallInst>(v));
+        }
+    ::llvm::Value * getPtr();
+::llvm::Value * getCount();
+::llvm::Value * getInitial();
+
+      };
+    
       class Add32Op : public ::llvm::CallInst {
         static const ::llvm::StringLiteral s_name; //{"xd.add32"};
 
@@ -263,6 +276,69 @@ bool verifier(::llvm::raw_ostream &errs);
 bool verifier(::llvm::raw_ostream &errs);
 
 ::llvm::Type * getSizeofType();
+
+::llvm::Value * getResult();
+
+
+      };
+    
+      class StreamAddOp : public StreamReduceOp {
+        static const ::llvm::StringLiteral s_name; //{"xd.stream.add"};
+
+      public:
+        static bool classof(const ::llvm::CallInst* i) {
+          return ::llvm_dialects::detail::isOverloadedOperation(i, s_name);
+        }
+        static bool classof(const ::llvm::Value* v) {
+          return ::llvm::isa<::llvm::CallInst>(v) &&
+                 classof(::llvm::cast<::llvm::CallInst>(v));
+        }
+    static StreamAddOp* create(::llvm_dialects::Builder& b, ::llvm::Value * ptr, ::llvm::Value * count, ::llvm::Value * initial);
+
+bool verifier(::llvm::raw_ostream &errs);
+
+
+::llvm::Value * getResult();
+
+
+      };
+    
+      class StreamMaxOp : public StreamReduceOp {
+        static const ::llvm::StringLiteral s_name; //{"xd.stream.max"};
+
+      public:
+        static bool classof(const ::llvm::CallInst* i) {
+          return ::llvm_dialects::detail::isOverloadedOperation(i, s_name);
+        }
+        static bool classof(const ::llvm::Value* v) {
+          return ::llvm::isa<::llvm::CallInst>(v) &&
+                 classof(::llvm::cast<::llvm::CallInst>(v));
+        }
+    static StreamMaxOp* create(::llvm_dialects::Builder& b, ::llvm::Value * ptr, ::llvm::Value * count, ::llvm::Value * initial);
+
+bool verifier(::llvm::raw_ostream &errs);
+
+
+::llvm::Value * getResult();
+
+
+      };
+    
+      class StreamMinOp : public StreamReduceOp {
+        static const ::llvm::StringLiteral s_name; //{"xd.stream.min"};
+
+      public:
+        static bool classof(const ::llvm::CallInst* i) {
+          return ::llvm_dialects::detail::isOverloadedOperation(i, s_name);
+        }
+        static bool classof(const ::llvm::Value* v) {
+          return ::llvm::isa<::llvm::CallInst>(v) &&
+                 classof(::llvm::cast<::llvm::CallInst>(v));
+        }
+    static StreamMinOp* create(::llvm_dialects::Builder& b, ::llvm::Value * ptr, ::llvm::Value * count, ::llvm::Value * initial);
+
+bool verifier(::llvm::raw_ostream &errs);
+
 
 ::llvm::Value * getResult();
 

--- a/test/example/test-builder.test
+++ b/test/example/test-builder.test
@@ -20,5 +20,8 @@
 ; CHECK-NEXT:    [[TMP12:%.*]] = call target("xd.vector", i32, 2) (...) @xd.insertelement.txd.vector_i32_2t(target("xd.vector", i32, 2) [[TMP7]], i32 [[TMP11]], i32 [[TMP0]])
 ; CHECK-NEXT:    [[TMP13:%.*]] = call target("xd.vector", i32, 2) (...) @xd.insertelement.txd.vector_i32_2t(target("xd.vector", i32, 2) [[TMP12]], i32 [[TMP9]], i32 1)
 ; CHECK-NEXT:    call void (...) @xd.write(target("xd.vector", i32, 2) [[TMP13]])
+; CHECK-NEXT:    [[TMP14:%.*]] = call ptr @xd.read.p0()
+; CHECK-NEXT:    [[TMP15:%.*]] = call i8 (...) @xd.stream.add.i8(ptr [[TMP14]], i64 14, i8 0)
+; CHECK-NEXT:    call void (...) @xd.write(i8 [[TMP15]])
 ; CHECK-NEXT:    ret void
 ;

--- a/test/example/verifier-basic.ll
+++ b/test/example/verifier-basic.ll
@@ -1,6 +1,6 @@
 ; RUN: not llvm-dialects-example -verify %s | FileCheck --check-prefixes=CHECK %s
 
-define void @test1() {
+define void @test1(ptr %p) {
 entry:
 ; CHECK-LABEL: Verifier error in: %sizeof1 =
 ; CHECK:  unexpected value of $result:
@@ -25,9 +25,21 @@ entry:
 ; CHECK:    expected:  2
 ; CHECK:    actual:    4
   %fromfixedvector2 = call target("xd.vector", i32, 2) (...) @xd.fromfixedvector.txd.vector_i32_2t(<4 x i32> poison)
+
+; CHECK-LABEL: Verifier error in:   %stream.max1 =
+; CHECK:  unexpected value of $result:
+; CHECK:    expected:  i16
+; CHECK:    actual:    <2 x i16>
+  %stream.max1 = call <2 x i16> (...) @xd.stream.max.v2i16(ptr %p, i64 %trunc1, i16 0)
+
+; CHECK-LABEL: Verifier error in:   %stream.min1 =
+; CHECK:  wrong number of arguments: 2, expected 3
+  %stream.min1 = call i8 (...) @xd.stream.min.i8(ptr %p, i64 14)
   ret void
 }
 
 declare i32 @xd.sizeof(...)
 declare i64 @xd.itrunc.i64(...)
 declare target("xd.vector", i32, 2) @xd.fromfixedvector.txd.vector_i32_2t(...)
+declare <2 x i16> @xd.stream.max.v2i16(...)
+declare i8 @xd.stream.min.i8(...)


### PR DESCRIPTION
OpClass allows a number of related operations to use a shared prefix of arguments. The idea is to use this for some shader I/O operations in LLPC that all need to talk about locations and components.

The support had regressed from my first steps in this direction due to the lack of tests and the recent major changes, so let's add some basic tests.