### PR TITLE
Fix issues when compiling with Clang

### DIFF
--- a/include/llvm-dialects/Dialect/ContextExtension.h
+++ b/include/llvm-dialects/Dialect/ContextExtension.h
@@ -36,7 +36,7 @@ class ContextExtensionKey {
 
 public:
   ContextExtensionKey();
-  ~ContextExtensionKey();
+  virtual ~ContextExtensionKey();
 
   unsigned getIndex() const { return m_index; }
 

--- a/include/llvm-dialects/Dialect/Verifier.h
+++ b/include/llvm-dialects/Dialect/Verifier.h
@@ -41,7 +41,9 @@ private:
   bool m_error = false;
 };
 
-using VerifierExtension = void(VisitorBuilder<VerifierState> &);
+struct VerifierExtension {
+  void (*build)(VisitorBuilder<VerifierState> &) = nullptr;
+};
 DialectExtensionPoint<VerifierExtension> &getVerifierExtensionPoint();
 
 bool verify(llvm::Module &module, llvm::raw_ostream &out);

--- a/include/llvm-dialects/TableGen/Predicates.h
+++ b/include/llvm-dialects/TableGen/Predicates.h
@@ -37,6 +37,8 @@ public:
     CppPredicate_Last = DialectType,
   };
 
+  virtual ~Predicate() = default;
+
   static std::unique_ptr<Predicate> parse(llvm::raw_ostream &errs,
                                           GenDialectsContext &context,
                                           llvm::Init *theInit);

--- a/lib/Dialect/Verifier.cpp
+++ b/lib/Dialect/Verifier.cpp
@@ -32,8 +32,8 @@ struct VerifierContextExtension
   static Visitor<VerifierState> build(LLVMContext &context) {
     VisitorBuilder<VerifierState> builder;
     auto extensions = getVerifierExtensionPoint().getExtensions(context);
-    for (VerifierExtension *extension : extensions)
-      (*extension)(builder);
+    for (const VerifierExtension *extension : extensions)
+      (*extension->build)(builder);
     return builder.build();
   }
 

--- a/lib/TableGen/GenDialect.cpp
+++ b/lib/TableGen/GenDialect.cpp
@@ -259,7 +259,7 @@ void llvm_dialects::genDialectDefs(raw_ostream& out, RecordKeeper& records) {
   {
     llvm::raw_string_ostream extra(makeExtra);
     extra << R"(
-      auto verifierExtension = [](::llvm_dialects::VisitorBuilder<::llvm_dialects::VerifierState> &builder) {
+      auto verifierBuild = [](::llvm_dialects::VisitorBuilder<::llvm_dialects::VerifierState> &builder) {
     )";
 
     for (const auto &opPtr : dialect->operations) {
@@ -276,8 +276,11 @@ void llvm_dialects::genDialectDefs(raw_ostream& out, RecordKeeper& records) {
 
     extra << tgfmt(R"(
       };
+      static const ::llvm_dialects::VerifierExtension verifierExtension = {
+        verifierBuild,
+      };
       static ::llvm_dialects::DialectExtensionRegistration<::llvm_dialects::VerifierExtension, $Dialect>
-          verifierExtensionRegistration(::llvm_dialects::getVerifierExtensionPoint(), verifierExtension);
+          verifierExtensionRegistration(::llvm_dialects::getVerifierExtensionPoint(), &verifierExtension);
     )",
                    &fmt);
   }

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -28,7 +28,7 @@ namespace xd {
 
     ::llvm_dialects::Dialect* ExampleDialect::make(::llvm::LLVMContext& context) {
       
-      auto verifierExtension = [](::llvm_dialects::VisitorBuilder<::llvm_dialects::VerifierState> &builder) {
+      auto verifierBuild = [](::llvm_dialects::VisitorBuilder<::llvm_dialects::VerifierState> &builder) {
     
         builder.add<Add32Op>([](::llvm_dialects::VerifierState &state, Add32Op &op) {
           if (!op.verifier(state.out()))
@@ -81,8 +81,11 @@ namespace xd {
         });
       
       };
+      static const ::llvm_dialects::VerifierExtension verifierExtension = {
+        verifierBuild,
+      };
       static ::llvm_dialects::DialectExtensionRegistration<::llvm_dialects::VerifierExtension, ExampleDialect>
-          verifierExtensionRegistration(::llvm_dialects::getVerifierExtensionPoint(), verifierExtension);
+          verifierExtensionRegistration(::llvm_dialects::getVerifierExtensionPoint(), &verifierExtension);
     
       return new ExampleDialect(context);
     }


### PR DESCRIPTION
The one actual error is rather strange:

    /vulkandriver/drivers/llpc/imported/llvm-dialects/include/llvm-dialects/Dialect/Dialect.h:215:13:
      error: reinterpret_cast from 'const void *' to 'void (*)(llvm_dialects::VisitorBuilder<llvm_dialects::VerifierState> &)'
             casts away qualifiers
                reinterpret_cast<const ExtensionT *>(m_extensions[i]));
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

One would think that `const ExtensionT *` with ExtensionT of function type would have a const qualifier. Gcc seems to think so, but Clang disagrees. Anyway, simply wrapping the function pointer in a struct ought to be enough to make the problem go away.

Clang also warned about some missing virtual destructors. The warning in Predicate was legitimate.