### PR TITLE
Add CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,36 @@
+Checks: '-*,clang-analyzer-*,clang-diagnostic-*,-clang-analyzer-core.CallAndMessage,-clang-analyzer-core.DivideZero,-clang-analyzer-core.NonNullParamChecker,-clang-analyzer-core.NullDereference,-clang-analyzer-core.uninitialized.UndefReturn,-clang-analyzer-core.UndefinedBinaryOperatorResult,-clang-analyzer-optin.cplusplus.VirtualCall,llvm-*,-llvm-include-order,-llvm-qualified-auto,-llvm-header-guard,performance-*,misc-*,-misc-no-recursion,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-simplify-boolean-expr,readability-redundant-nullptr-comparison,readability-redundant-parentheses,readability-declaration-inline-comment'
+CheckOptions:
+  - { key: readability-identifier-naming.ParameterCase, value: camelBack }
+  - { key: readability-identifier-naming.ParameterRemovePrefixes, value: 'p,b,pfn' }
+  - { key: readability-identifier-naming.VariableCase, value: camelBack }
+  - { key: readability-identifier-naming.VariableRemovePrefixes, value: 'p,b,pfn' }
+  # Need to ignore static field 'ID' because otherwise clang-tidy dives into an llvm
+  # include file and changes 'ID' to 'm_id' there, which is bad.
+  - { key: readability-identifier-naming.ClassMemberIgnoredRegexp, value: '^ID|mm.*$' }
+  - { key: readability-identifier-naming.ClassMemberCase, value: camelBack }
+  - { key: readability-identifier-naming.ClassMemberRemovePrefixes, value: 'p,b,pfn,m_p,m_b' }
+  - { key: readability-identifier-naming.ClassMemberPrefix, value: m_ }
+  - { key: readability-identifier-naming.ClassConstantCase, value: CamelCase }
+  - { key: readability-identifier-naming.ClassConstantRemovePrefixes, value: 'p,b,pfn,m_p,m_b' }
+  - { key: readability-identifier-naming.StaticVariableCase, value: CamelCase }
+  - { key: readability-identifier-naming.StaticVariableRemovePrefixes, value: 'p,b,pfn,s_,s_p' }
+  - { key: readability-identifier-naming.GlobalVariableIgnoredRegexp, value: 'mm.*' }
+  - { key: readability-identifier-naming.GlobalVariableCase, value: CamelCase }
+  - { key: readability-identifier-naming.GlobalVariableRemovePrefixes, value: 'p,b,pfn,g_,g_p' }
+  - { key: readability-identifier-naming.ConstantMemberIgnoredRegexp, value: 'mm.*' }
+  - { key: readability-identifier-naming.ConstantMemberCase, value: camelBack }
+  - { key: readability-identifier-naming.ConstantMemberRemovePrefixes, value: 'p,b,pfn,m_p,m_b' }
+  - { key: readability-identifier-naming.ConstantMemberPrefix, value: m_ }
+  - { key: readability-identifier-naming.PublicMemberCase, value: camelBack }
+  - { key: readability-identifier-naming.PublicMemberIgnoredRegexp, value: '^pSymName$' }
+  - { key: readability-identifier-naming.PublicMemberPrefix, value: '' }
+  - { key: readability-identifier-naming.PublicMemberRemovePrefixes, value: 'p,b,pfn,m_,m_p,m_b' }
+  - { key: readability-identifier-naming.MemberCase, value: camelBack }
+  - { key: readability-identifier-naming.MemberPrefix, value: m_ }
+  - { key: readability-identifier-naming.MemberRemovePrefixes, value: 'p,b,pfn,m_p,m_b' }
+  - { key: readability-identifier-naming.MethodCase, value: camelBack }
+  - { key: readability-identifier-naming.MethodIgnoredRegexp, value: '^Create$|^CreateACos$|^CreateACosh$|^CreateASin$|^CreateASinh$|^CreateATan$|^CreateATan2$|^CreateATanh$|^CreateBarrier$|^CreateBinaryIntrinsic$|^CreateCosh$|^CreateCrossProduct$|^CreateCubeFace.*$|^CreateDemoteToHelperInvocation$|^CreateDerivative$|^CreateDeterminant$|^CreateDotProduct$|^CreateEmitVertex$|^CreateEndPrimitive$|^CreateExp$|^CreateExtract.*$|^CreateFaceForward$|^CreateFClamp$|^CreateFindSMsb$|^CreateFma$|^CreateFMax$|^CreateFMax3$|^CreateFMid3$|^CreateFMin$|^CreateFMin3$|^CreateFMod$|^CreateFpTruncWithRounding$|^CreateFract$|^CreateFSign$|^CreateGet.*$|^CreateImage.*$|^CreateIndexDescPtr$|^CreateInsertBitField$|^CreateIntrinsic$|^CreateInverseSqrt$|^CreateIs.*$|^CreateKill$|^CreateLdexp$|^CreateLoad.*$|^CreateLog$|^CreateMapToInt32$|^CreateMatrix.*$|^CreateNormalizeVector$|^CreateOuterProduct$|^CreatePower$|^CreateQuantizeToFp16$|^CreateRead.*$|^CreateReflect$|^CreateRefract$|^CreateSAbs$|^CreateSinh$|^CreateSMod$|^CreateSmoothStep$|^CreateSSign$|^CreateSubgroup.*$|^CreateTan$|^CreateTanh$|^CreateTransposeMatrix$|^CreateUnaryIntrinsic$|^CreateVectorTimesMatrix$|^CreateWrite.*Output$|^Serialize$|^Merge$|^Destroy$|^ConvertColorBufferFormatToExportFormat$|^BuildShaderModule$|^BuildGraphicsPipeline$|^BuildComputePipeline$|^IsVertexFormatSupported$|^DumpSpirvBinary$|^BeginPipelineDump$|^EndPipelineDump$|^DumpPipelineBinary$|^DumpPipelineExtraInfo$|^GetShaderHash$|^GetPipelineHash$|^GetPipelineName$|^CreateShaderCache$|^ReadFromBuffer$|^GetSectionIndex$|^GetSymbolsBySectionIndex$|^GetSectionData$' }
+  - { key: readability-identifier-naming.FunctionIgnoredRegexp, value: 'EnableOuts|EnableErrs' }
+  - { key: readability-identifier-naming.FunctionCase, value: camelBack }
+  - { key: readability-identifier-naming.TypeCase, value: CamelCase }
+  - { key: readability-identifier-naming.TypeRemovePrefixes, value: PFN_ }

--- a/.github/workflows/check-clang-tidy.yml
+++ b/.github/workflows/check-clang-tidy.yml
@@ -1,0 +1,29 @@
+name: Code style check
+
+on:
+  pull_request:
+
+jobs:
+  clang-tidy:
+    name: clang-tidy
+    runs-on: "ubuntu-22.04"
+    steps:
+      - name: Checkout LLPC
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY}.git .
+          git fetch origin +${GITHUB_SHA}:${GITHUB_REF} --update-head-ok
+          git checkout ${GITHUB_SHA}
+      - name: Generate Docker base image tag string
+        run: |
+          echo "IMAGE_TAG=amdvlkadmin/amdvlk_release_clang:nightly" \
+            | tee -a $GITHUB_ENV
+      - name: Fetch the latest prebuilt AMDVLK
+        run: docker pull "$IMAGE_TAG"
+      - name: Build and Test with Docker
+        run: docker build . --file docker/dialects-clang-tidy.Dockerfile
+                            --build-arg AMDVLK_IMAGE="$IMAGE_TAG"
+                            --build-arg DIALECTS_REPO_NAME="${GITHUB_REPOSITORY}"
+                            --build-arg DIALECTS_REPO_REF="${GITHUB_REF}"
+                            --build-arg DIALECTS_REPO_SHA="${GITHUB_SHA}"
+                            --build-arg DIALECTS_BASE_REF="${{ github.base_ref }}"
+                            --tag dialects/ci-dialects

--- a/.github/workflows/check-dialects-docker.yml
+++ b/.github/workflows/check-dialects-docker.yml
@@ -1,0 +1,52 @@
+name: Dialects Docker CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    name: "Features: ${{ matrix.feature-set }}"
+    runs-on: ${{ matrix.host-os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        host-os:             ["ubuntu-22.04"]
+        image-template:      ["amdvlkadmin/amdvlk_%s%s:nightly"]
+        config:              [Release]
+        feature-set:         ["+gcc", "+gcc+assertions",
+                              "+clang",
+                              "+clang+shadercache+ubsan+asan",
+                              "+clang+shadercache+ubsan+asan+assertions"]
+    steps:
+      - name: Free up disk space
+        if: contains(matrix.feature-set, '+ubsan') || contains(matrix.feature-set, '+asan') || contains(matrix.feature-set, '+tsan') || contains(matrix.feature-set, '+coverage')
+        run: |
+          echo 'Before:' && df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/hostedtoolcache/boost /opt/ghc \
+                      /usr/lib/jvm /opt/hostedtoolcache/go /opt/hostedtoolcache/CodeQL /opt/az \
+                      /usr/share/swift /usr/local/.ghcup /usr/local/graalvm /usr/local/lib/node_modules
+          echo 'After:' && df -h
+      - name: Checkout dialects
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY}.git .
+          git fetch origin +${GITHUB_SHA}:${GITHUB_REF} --update-head-ok
+          git checkout ${GITHUB_SHA}
+      - name: Generate Docker base image tag string
+        run: |
+          CONFIG_LOWER=$(echo "${{ matrix.config }}" | tr "[:upper:]" "[:lower:]")
+          FEATURES_LOWER=$(echo "${{ matrix.feature-set }}" | tr "+" "_")
+          TAG=$(printf "${{ matrix.image-template }}" "$CONFIG_LOWER" "$FEATURES_LOWER")
+          echo "IMAGE_TAG=$TAG" | tee -a $GITHUB_ENV
+          CONFIG_TAG=$(printf "%s%s" "$CONFIG_LOWER" "$FEATURES_LOWER")
+          echo "CONFIG_TAG=$CONFIG_TAG" | tee -a $GITHUB_ENV
+      - name: Fetch the latest prebuilt AMDVLK
+        run: docker pull "$IMAGE_TAG"
+      - name: Build and Test with Docker
+        run: docker build . --file docker/Dockerfile
+                             --build-arg AMDVLK_IMAGE="$IMAGE_TAG"
+                             --build-arg DIALECTS_REPO_NAME="${GITHUB_REPOSITORY}"
+                             --build-arg DIALECTS_REPO_REF="${GITHUB_REF}"
+                             --build-arg DIALECTS_REPO_SHA="${GITHUB_SHA}"
+                             --build-arg FEATURES="${{ matrix.feature-set }}"
+                             --tag dialects/ci-dialects

--- a/.github/workflows/check-dialects-docker.yml
+++ b/.github/workflows/check-dialects-docker.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Fetch the latest prebuilt AMDVLK
         run: docker pull "$IMAGE_TAG"
       - name: Build and Test with Docker
-        run: docker build . --file docker/Dockerfile
+        run: docker build . --file docker/dialects.Dockerfile
                              --build-arg AMDVLK_IMAGE="$IMAGE_TAG"
                              --build-arg DIALECTS_REPO_NAME="${GITHUB_REPOSITORY}"
                              --build-arg DIALECTS_REPO_REF="${GITHUB_REF}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,43 @@
+#
+# Dockerfile for llvm-dialects Continuous Integration.
+# Sample invocation:
+#    docker build .                                                                                       \
+#      --file docker/Dockerfile                                                                           \
+#      --build-arg AMDVLK_IMAGE=amdvlkadmin/amdvlk_release_gcc_assertions:nightly                         \
+#      --build-arg DIALECTS_REPO_NAME=GPUOpen-Drivers/llvm-dialects                                       \
+#      --build-arg DIALECTS_REPO_REF=<GIT_REF>                                                            \
+#      --build-arg DIALECTS_REPO_SHA=<GIT_SHA>                                                            \
+#      --tag dialects-ci/dialects
+#
+# Required arguments:
+# - AMDVLK_IMAGE: Base image name for prebuilt amdvlk
+# - DIALECTS_REPO_NAME: Name of the llpc repository to clone
+# - DIALECTS_REPO_REF: ref name to checkout
+# - DIALECTS_REPO_SHA: SHA of the commit to checkout
+#
+
+# Resume build from the specified image.
+ARG AMDVLK_IMAGE
+FROM "$AMDVLK_IMAGE"
+
+ARG DIALECTS_REPO_NAME
+ARG DIALECTS_REPO_REF
+ARG DIALECTS_REPO_SHA
+
+# Use bash instead of sh in this docker file.
+SHELL ["/bin/bash", "-c"]
+
+# Copy helper scripts into container.
+COPY docker/*.sh /vulkandriver/
+
+# Sync the repos. Replace the base repo with a freshly checked-out one.
+RUN /vulkandriver/update-dialects.sh
+
+# Build llvm-dialects.
+WORKDIR /vulkandriver/builds/ci-build
+RUN source /vulkandriver/env.sh \
+    && cmake --build . --target llvm-dialects-tblgen
+
+# Run the lit test suite.
+RUN source /vulkandriver/env.sh \
+    && cmake --build . --target check-llvm-dialects -- -v

--- a/docker/dialects-clang-tidy.Dockerfile
+++ b/docker/dialects-clang-tidy.Dockerfile
@@ -1,0 +1,62 @@
+#
+# Dockerfile for llvm-dialects Continuous Integration.
+# Sample invocation:
+#    docker build .                                                                                       \
+#      --file docker/dialects-clang-tidy.Dockerfile                                                       \
+#      --build-arg AMDVLK_IMAGE=amdvlkadmin/amdvlk_release_clang:nightly                                  \
+#      --build-arg DIALECTS_REPO_NAME=GPUOpen-Drivers/llvm-dialects                                       \
+#      --build-arg DIALECTS_REPO_REF=<GIT_REF>                                                            \
+#      --build-arg DIALECTS_REPO_SHA=<GIT_SHA>                                                            \
+#      --tag dialects-ci/dialects
+#
+# Required arguments:
+# - AMDVLK_IMAGE: Base image name for prebuilt amdvlk
+# - DIALECTS_REPO_NAME: Name of the llvm-dialects repository to clone
+# - DIALECTS_REPO_REF: ref name to checkout
+# - DIALECTS_REPO_SHA: SHA of the commit to checkout
+# - DIALECTS_BASE_REF: ref name for the base of the tested change
+#
+
+# Resume build from the specified image.
+ARG AMDVLK_IMAGE
+FROM "$AMDVLK_IMAGE"
+
+ARG DIALECTS_REPO_NAME
+ARG DIALECTS_REPO_REF
+ARG DIALECTS_REPO_SHA
+ARG DIALECTS_BASE_REF
+
+# Use bash instead of sh in this docker file.
+SHELL ["/bin/bash", "-c"]
+
+# Copy helper scripts into container.
+COPY docker/*.sh /vulkandriver/
+
+RUN /vulkandriver/update-dialects.sh
+RUN git -C /vulkandriver/drivers/llpc/imported/llvm-dialects fetch origin "$DIALECTS_BASE_REF" --update-head-ok
+
+# Run CMake.
+WORKDIR /vulkandriver/builds/ci-build
+RUN source /vulkandriver/env.sh \
+    && cmake .
+
+# Run clang-tidy. Detect failures by searching for a colon. An empty line or "No relevant changes found." signals success.
+WORKDIR /vulkandriver/drivers/llpc/imported/llvm-dialects
+RUN ln -s /vulkandriver/builds/ci-build/compile_commands.json \
+    && git diff "origin/$DIALECTS_BASE_REF" -U0 \
+         | /vulkandriver/drivers/llvm-project/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py \
+             -p1 -j$(nproc) -iregex '.*\\.(cpp|cc|c\\+\\+|cxx|c|cl|h|hpp|m|mm)' >not-tidy.diff \
+    && if ! grep -q : not-tidy.diff ; then \
+        echo "Clean code. Success."; \
+    else \
+        echo "Code not tidy."; \
+        echo "Please run clang-tidy-diff on your changes and push again:"; \
+        echo "    git diff origin/$DIALECTS_BASE_REF -U0 --no-color | ../llvm-project/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py -p1 -fix"; \
+        echo ""; \
+        echo "To disable a lint, add \`// NOLINT\` at the end of the line."; \
+        echo ""; \
+        echo "Diff:"; \
+        cat not-tidy.diff; \
+        echo ""; \
+        exit 3; \
+    fi

--- a/docker/dialects.Dockerfile
+++ b/docker/dialects.Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile for llvm-dialects Continuous Integration.
 # Sample invocation:
 #    docker build .                                                                                       \
-#      --file docker/Dockerfile                                                                           \
+#      --file docker/dialects.Dockerfile                                                                  \
 #      --build-arg AMDVLK_IMAGE=amdvlkadmin/amdvlk_release_gcc_assertions:nightly                         \
 #      --build-arg DIALECTS_REPO_NAME=GPUOpen-Drivers/llvm-dialects                                       \
 #      --build-arg DIALECTS_REPO_REF=<GIT_REF>                                                            \
@@ -11,7 +11,7 @@
 #
 # Required arguments:
 # - AMDVLK_IMAGE: Base image name for prebuilt amdvlk
-# - DIALECTS_REPO_NAME: Name of the llpc repository to clone
+# - DIALECTS_REPO_NAME: Name of the llvm-dialects repository to clone
 # - DIALECTS_REPO_REF: ref name to checkout
 # - DIALECTS_REPO_SHA: SHA of the commit to checkout
 #

--- a/docker/update-dialects.sh
+++ b/docker/update-dialects.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Update the driver and clone a specified version of dialects.
+set -e
+
+# Sync the repos. Replace the base llvm-dialects with a freshly checked-out one.
+cat /vulkandriver/build_info.txt
+(cd /vulkandriver && repo sync -c --no-clone-bundle -j$(nproc))
+git -C /vulkandriver/drivers/llpc/imported/llvm-dialects remote add origin https://github.com/"$DIALECTS_REPO_NAME".git
+git -C /vulkandriver/drivers/llpc/imported/llvm-dialects fetch origin +"$DIALECTS_REPO_SHA":"$DIALECTS_REPO_REF" --update-head-ok
+git -C /vulkandriver/drivers/llpc/imported/llvm-dialects checkout "$DIALECTS_REPO_SHA"
+git -C /vulkandriver/drivers/llpc/imported/llvm-dialects submodule update --init

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(llvm-dialects-example
     PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR})
 
-llvm_map_components_to_libnames(llvm_libs Support Core)
+llvm_map_components_to_libnames(llvm_libs AsmParser Support Core)
 target_link_libraries(llvm-dialects-example
     PRIVATE
     llvm_dialects


### PR DESCRIPTION
Add a CI based on the docker images built for amdvlk.
I wanted to use apt.llvm.org first, but we don’t have any control over
the llvm commit used, which would regularly break the CI build when
llvm’s C++ API changes.

This CI build fetches the amdvlk base docker image, updates the
llvm-dialects submodule and runs the tests.

Also, fix compiling with shared libraries. A reference to AsmParser was
missing and add an assert that checks for out-of-bounds vector accesses.
The vector is sometimes accessed out-of-bounds, leading to inconsistent
behavior (like asserting in debug mode, but running through when run in a debugger).

The build here will not pass, because of the afore mentioned oob access, here’s a passing build with a workaround: https://github.com/Flakebi/llvm-dialects/actions/runs/4264669825