### PR TITLE
More visitor features

### DIFF
--- a/example/ExampleMain.cpp
+++ b/example/ExampleMain.cpp
@@ -146,6 +146,10 @@ struct VisitorInnermost {
 struct VisitorNest {
   raw_ostream *out = nullptr;
   VisitorInnermost inner;
+
+  void visitBinaryOperator(BinaryOperator &inst) {
+    *out << "visiting BinaryOperator: " << inst << '\n';
+  }
 };
 
 struct VisitorContainer {
@@ -179,9 +183,7 @@ template <bool rpot> const Visitor<VisitorContainer> &getExampleVisitor() {
                 [](VisitorNest &self, UnaryInstruction &inst) {
                   *self.out << "visiting UnaryInstruction: " << inst << '\n';
                 });
-            b.add<BinaryOperator>([](VisitorNest &self, BinaryOperator &inst) {
-              *self.out << "visiting BinaryOperator: " << inst << '\n';
-            });
+            b.add(&VisitorNest::visitBinaryOperator);
             b.nest<raw_ostream>([](VisitorBuilder<raw_ostream> &b) {
               b.add<xd::WriteOp>([](raw_ostream &out, xd::WriteOp &op) {
                 out << "visiting WriteOp: " << op << '\n';

--- a/example/ExampleMain.cpp
+++ b/example/ExampleMain.cpp
@@ -30,6 +30,8 @@
 
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IRPrinter/IRPrintingPasses.h"
 #include "llvm/Support/CommandLine.h"
@@ -173,10 +175,24 @@ template <bool rpot> const Visitor<VisitorContainer> &getExampleVisitor() {
             b.add<xd::ReadOp>([](VisitorNest &self, xd::ReadOp &op) {
               *self.out << "visiting ReadOp: " << op << '\n';
             });
+            b.add<UnaryInstruction>(
+                [](VisitorNest &self, UnaryInstruction &inst) {
+                  *self.out << "visiting UnaryInstruction: " << inst << '\n';
+                });
+            b.add<BinaryOperator>([](VisitorNest &self, BinaryOperator &inst) {
+              *self.out << "visiting BinaryOperator: " << inst << '\n';
+            });
             b.nest<raw_ostream>([](VisitorBuilder<raw_ostream> &b) {
               b.add<xd::WriteOp>([](raw_ostream &out, xd::WriteOp &op) {
                 out << "visiting WriteOp: " << op << '\n';
               });
+              b.add<ReturnInst>([](raw_ostream &out, ReturnInst &ret) {
+                out << "visiting ReturnInst: " << ret << '\n';
+              });
+              b.addIntrinsic(
+                  Intrinsic::umax, [](raw_ostream &out, IntrinsicInst &umax) {
+                    out << "visiting umax intrinsic: " << umax << '\n';
+                  });
             });
             b.nest<VisitorInnermost>([](VisitorBuilder<VisitorInnermost> &b) {
               b.add<xd::ITruncOp>([](VisitorInnermost &inner,

--- a/lib/Dialect/OpDescription.cpp
+++ b/lib/Dialect/OpDescription.cpp
@@ -20,11 +20,41 @@
 
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
 
 using namespace llvm_dialects;
 using namespace llvm;
 
+OpDescription::OpDescription(Kind kind, MutableArrayRef<unsigned> opcodes)
+    : m_kind(kind), m_op(opcodes) {
+  llvm::sort(opcodes);
+}
+
+ArrayRef<unsigned> OpDescription::getOpcodes() const {
+  assert(m_kind == Kind::Core || m_kind == Kind::Intrinsic);
+
+  if (auto *op = std::get_if<unsigned>(&m_op))
+    return *op;
+
+  return std::get<ArrayRef<unsigned>>(m_op);
+}
+
 bool OpDescription::matchInstruction(Instruction &inst) const {
+  if (m_kind == Kind::Intrinsic) {
+    if (auto *intr = dyn_cast<IntrinsicInst>(&inst))
+      return matchIntrinsic(intr->getIntrinsicID());
+    return false;
+  }
+
+  if (m_kind == Kind::Core) {
+    if (auto *op = std::get_if<unsigned>(&m_op))
+      return inst.getOpcode() == *op;
+
+    auto opcodes = std::get<ArrayRef<unsigned>>(m_op);
+    auto it = llvm::lower_bound(opcodes, inst.getOpcode());
+    return it != opcodes.end() && *it == inst.getOpcode();
+  }
+
   if (auto *call = dyn_cast<CallInst>(&inst)) {
     if (auto *fn = call->getCalledFunction())
       return matchDeclaration(*fn);
@@ -33,7 +63,268 @@ bool OpDescription::matchInstruction(Instruction &inst) const {
 }
 
 bool OpDescription::matchDeclaration(Function &decl) const {
-  if (m_hasOverloads)
-    return llvm_dialects::detail::isOverloadedOperationDecl(&decl, m_mnemonic);
-  return llvm_dialects::detail::isSimpleOperationDecl(&decl, m_mnemonic);
+  if (auto *mnemonic = std::get_if<StringRef>(&m_op)) {
+    if (m_kind == Kind::DialectWithOverloads)
+      return llvm_dialects::detail::isOverloadedOperationDecl(&decl, *mnemonic);
+    assert(m_kind == Kind::Dialect);
+    return llvm_dialects::detail::isSimpleOperationDecl(&decl, *mnemonic);
+  }
+
+  assert(m_kind == Kind::Intrinsic);
+  return matchIntrinsic(decl.getIntrinsicID());
 }
+
+bool OpDescription::matchIntrinsic(unsigned intrinsicId) const {
+  assert(m_kind == Kind::Intrinsic);
+
+  if (auto *op = std::get_if<unsigned>(&m_op))
+    return *op == intrinsicId;
+
+  auto opcodes = std::get<ArrayRef<unsigned>>(m_op);
+  auto it = llvm::lower_bound(opcodes, intrinsicId);
+  return it != opcodes.end() && *it == intrinsicId;
+}
+
+// ============================================================================
+// Descriptions of core instructions.
+
+template <> const OpDescription &OpDescription::get<UnaryInstruction>() {
+  static unsigned opcodes[] = {
+      Instruction::Alloca,
+      Instruction::Load,
+      Instruction::VAArg,
+      Instruction::ExtractValue,
+
+#define HANDLE_UNARY_INST(num, opcode, Class) Instruction::opcode,
+#define HANDLE_CAST_INST(num, opcode, Class) Instruction::opcode,
+#include "llvm/IR/Instruction.def"
+  };
+  static const OpDescription desc{Kind::Core, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<BinaryOperator>() {
+  static unsigned opcodes[] = {
+#define HANDLE_BINARY_INST(num, opcode, Class) Instruction::opcode,
+#include "llvm/IR/Instruction.def"
+  };
+  static const OpDescription desc{Kind::Core, opcodes};
+  return desc;
+}
+
+// Generate OpDescription for all dedicate instruction classes.
+#define HANDLE_USER_INST(...)
+#define HANDLE_UNARY_INST(...)
+#define HANDLE_BINARY_INST(...)
+#define HANDLE_INST(num, opcode, Class)                                        \
+  template <> const OpDescription &OpDescription::get<Class>() {               \
+    static const OpDescription desc{Kind::Core, Instruction::opcode};          \
+    return desc;                                                               \
+  }
+#include "llvm/IR/Instruction.def"
+
+// ============================================================================
+// Descriptions of intrinsic facades implemented in LLVM
+
+template <> const OpDescription &OpDescription::get<LifetimeIntrinsic>() {
+  static unsigned opcodes[] = {
+      Intrinsic::lifetime_start,
+      Intrinsic::lifetime_end,
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<DbgInfoIntrinsic>() {
+  static unsigned opcodes[] = {
+      Intrinsic::dbg_declare, Intrinsic::dbg_value, Intrinsic::dbg_label,
+      Intrinsic::dbg_assign,
+      // Intrinsic::dbg_addr, <-- add this back for sufficiently recent LLVM
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<DbgVariableIntrinsic>() {
+  static unsigned opcodes[] = {
+      Intrinsic::dbg_declare,
+      Intrinsic::dbg_value,
+      // Intrinsic::dbg_addr, <-- add this back for sufficiently recent LLVM
+      Intrinsic::dbg_assign,
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<DbgDeclareInst>() {
+  static const OpDescription desc{Kind::Intrinsic, Intrinsic::dbg_declare};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<DbgValueInst>() {
+  static const OpDescription desc{Kind::Intrinsic, Intrinsic::dbg_value};
+  return desc;
+}
+
+// Add this back for sufficiently recent LLVM
+// template <> const OpDescription &OpDescription::get<DbgAddrIntrinsic>() {
+//   static const OpDescription desc{Kind::Intrinsic, Intrinsic::dbg_addr};
+//   return desc;
+// }
+
+template <> const OpDescription &OpDescription::get<DbgAssignIntrinsic>() {
+  static const OpDescription desc{Kind::Intrinsic, Intrinsic::dbg_assign};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<DbgLabelInst>() {
+  static const OpDescription desc{Kind::Intrinsic, Intrinsic::dbg_label};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<AtomicMemIntrinsic>() {
+  static unsigned opcodes[] = {
+      Intrinsic::memcpy_element_unordered_atomic,
+      Intrinsic::memmove_element_unordered_atomic,
+      Intrinsic::memset_element_unordered_atomic,
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<AtomicMemSetInst>() {
+  static const OpDescription desc{Kind::Intrinsic,
+                                  Intrinsic::memset_element_unordered_atomic};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<AtomicMemTransferInst>() {
+  static unsigned opcodes[] = {
+      Intrinsic::memcpy_element_unordered_atomic,
+      Intrinsic::memmove_element_unordered_atomic,
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<AtomicMemCpyInst>() {
+  static const OpDescription desc{Kind::Intrinsic,
+                                  Intrinsic::memcpy_element_unordered_atomic};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<AtomicMemMoveInst>() {
+  static const OpDescription desc{Kind::Intrinsic,
+                                  Intrinsic::memmove_element_unordered_atomic};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<MemIntrinsic>() {
+  static unsigned opcodes[] = {
+      Intrinsic::memcpy,        Intrinsic::memmove,       Intrinsic::memset,
+      Intrinsic::memset_inline, Intrinsic::memcpy_inline,
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<MemSetInst>() {
+  static unsigned opcodes[] = {
+      Intrinsic::memset,
+      Intrinsic::memset_inline,
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<MemSetInlineInst>() {
+  static const OpDescription desc{Kind::Intrinsic, Intrinsic::memset_inline};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<MemTransferInst>() {
+  static unsigned opcodes[] = {
+      Intrinsic::memcpy,
+      Intrinsic::memmove,
+      Intrinsic::memcpy_inline,
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<MemCpyInst>() {
+  static unsigned opcodes[] = {
+      Intrinsic::memcpy,
+      Intrinsic::memcpy_inline,
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<MemMoveInst>() {
+  static const OpDescription desc{Kind::Intrinsic, Intrinsic::memmove};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<MemCpyInlineInst>() {
+  static const OpDescription desc{Kind::Intrinsic, Intrinsic::memcpy_inline};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<AnyMemIntrinsic>() {
+  static unsigned opcodes[] = {
+      Intrinsic::memcpy,
+      Intrinsic::memcpy_inline,
+      Intrinsic::memmove,
+      Intrinsic::memset,
+      Intrinsic::memset_inline,
+      Intrinsic::memcpy_element_unordered_atomic,
+      Intrinsic::memmove_element_unordered_atomic,
+      Intrinsic::memset_element_unordered_atomic,
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<AnyMemSetInst>() {
+  static unsigned opcodes[] = {
+      Intrinsic::memset,
+      Intrinsic::memset_inline,
+      Intrinsic::memset_element_unordered_atomic,
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<AnyMemTransferInst>() {
+  static unsigned opcodes[] = {
+      Intrinsic::memcpy,
+      Intrinsic::memcpy_inline,
+      Intrinsic::memmove,
+      Intrinsic::memcpy_element_unordered_atomic,
+      Intrinsic::memmove_element_unordered_atomic,
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<AnyMemCpyInst>() {
+  static unsigned opcodes[] = {
+      Intrinsic::memcpy,
+      Intrinsic::memcpy_inline,
+      Intrinsic::memcpy_element_unordered_atomic,
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+template <> const OpDescription &OpDescription::get<AnyMemMoveInst>() {
+  static unsigned opcodes[] = {
+      Intrinsic::memmove,
+      Intrinsic::memmove_element_unordered_atomic,
+  };
+  static const OpDescription desc{Kind::Intrinsic, opcodes};
+  return desc;
+}
+
+// TODO: Is completing this list worth it?

--- a/lib/Dialect/Visitor.cpp
+++ b/lib/Dialect/Visitor.cpp
@@ -30,6 +30,7 @@ using namespace llvm;
 
 using llvm_dialects::detail::VisitorBase;
 using llvm_dialects::detail::VisitorBuilderBase;
+using llvm_dialects::detail::VisitorCallbackData;
 using llvm_dialects::detail::VisitorHandler;
 using llvm_dialects::detail::VisitorKey;
 using llvm_dialects::detail::VisitorTemplate;
@@ -43,11 +44,11 @@ void VisitorTemplate::setStrategy(VisitorStrategy strategy) {
   m_strategy = strategy;
 }
 
-void VisitorTemplate::add(VisitorKey key, void *extra, VisitorCallback *fn,
-                          ssize_t projection) {
+void VisitorTemplate::add(VisitorKey key, VisitorCallback *fn,
+                          VisitorCallbackData data, ssize_t projection) {
   VisitorHandler handler;
   handler.callback = fn;
-  handler.callbackData = extra;
+  handler.data = data;
   handler.projection = projection;
   m_handlers.emplace_back(handler);
 
@@ -140,8 +141,9 @@ void VisitorBuilderBase::setStrategy(VisitorStrategy strategy) {
   m_template->setStrategy(strategy);
 }
 
-void VisitorBuilderBase::add(VisitorKey key, void *extra, VisitorCallback *fn) {
-  m_template->add(key, extra, fn, m_projection);
+void VisitorBuilderBase::add(VisitorKey key, VisitorCallback *fn,
+                             VisitorCallbackData data) {
+  m_template->add(key, fn, data, m_projection);
 }
 
 VisitorBase VisitorBuilderBase::build() {
@@ -220,7 +222,7 @@ void VisitorBase::call(const VisitorHandler &handler, void *payload,
       payload = m_projections[idx].projection(payload);
     }
   }
-  handler.callback(handler.callbackData, payload, &inst);
+  handler.callback(handler.data, payload, &inst);
 }
 
 void VisitorBase::visit(void *payload, Instruction &inst) const {

--- a/lib/Dialect/Visitor.cpp
+++ b/lib/Dialect/Visitor.cpp
@@ -30,62 +30,11 @@ using namespace llvm;
 
 using llvm_dialects::detail::VisitorBase;
 using llvm_dialects::detail::VisitorBuilderBase;
+using llvm_dialects::detail::VisitorHandler;
 using llvm_dialects::detail::VisitorKey;
+using llvm_dialects::detail::VisitorTemplate;
 
-bool VisitorKey::matchInstruction(Instruction &inst) const {
-  if (m_kind == Kind::Intrinsic) {
-    if (auto *intrinsicInst = dyn_cast<IntrinsicInst>(&inst))
-      return intrinsicInst->getIntrinsicID() == m_intrinsicId;
-    return false;
-  }
-
-  return m_description->matchInstruction(inst);
-}
-
-bool VisitorKey::matchDeclaration(Function &decl) const {
-  if (m_kind == Kind::Intrinsic)
-    return decl.getIntrinsicID() == m_intrinsicId;
-
-  return m_description->matchDeclaration(decl);
-}
-
-VisitorBuilderBase::~VisitorBuilderBase() {
-  if (m_parent) {
-    // Build up the projection sequence by walking all the way to the root.
-    SmallVector<PayloadProjection> projectionSequence;
-    projectionSequence.emplace_back();
-
-    VisitorBuilderBase *ancestor = this;
-    for (; ancestor->m_parent; ancestor = ancestor->m_parent) {
-      if (ancestor->m_projection) {
-        PayloadProjection next;
-        next.projection = ancestor->m_projection;
-        projectionSequence.push_back(next);
-      } else {
-        projectionSequence.back().offset += ancestor->m_offsetProjection;
-      }
-    }
-
-    ssize_t projection = 0;
-    if (projectionSequence.size() == 1) {
-      projection = projectionSequence[0].offset;
-    } else {
-      projection = -(1 + ancestor->m_projections.size());
-      ancestor->m_projections.append(projectionSequence.rbegin(),
-                                     projectionSequence.rend());
-    }
-
-    for (auto &theCase : m_cases)
-      theCase.projection = projection;
-
-    // Copy all cases to the root.
-    ancestor->m_cases.append(m_cases.begin(), m_cases.end());
-
-    ancestor->setStrategy(m_strategy);
-  }
-}
-
-void VisitorBuilderBase::setStrategy(VisitorStrategy strategy) {
+void VisitorTemplate::setStrategy(VisitorStrategy strategy) {
   if (strategy == VisitorStrategy::Default)
     return;
 
@@ -94,47 +43,254 @@ void VisitorBuilderBase::setStrategy(VisitorStrategy strategy) {
   m_strategy = strategy;
 }
 
-void VisitorBuilderBase::add(VisitorKey key, void *extra, VisitorCallback *fn) {
-  VisitorCase theCase{key};
-  theCase.callback = fn;
-  theCase.callbackData = extra;
-  theCase.projection = 0;
-  m_cases.emplace_back(theCase);
-}
+void VisitorTemplate::add(VisitorKey key, void *extra, VisitorCallback *fn,
+                          ssize_t projection) {
+  VisitorHandler handler;
+  handler.callback = fn;
+  handler.callbackData = extra;
+  handler.projection = projection;
+  m_handlers.emplace_back(handler);
 
-VisitorBase::VisitorBase(VisitorBuilderBase &&builder)
-    : m_strategy(builder.m_strategy), m_cases(std::move(builder.m_cases)),
-      m_projections(std::move(builder.m_projections)) {
-  assert(!builder.m_parent);
+  unsigned handlerIdx = m_handlers.size() - 1;
 
-  if (m_strategy == VisitorStrategy::Default) {
-    bool matchDeclarations = all_of(m_cases, [](const VisitorCase &theCase) {
-      return theCase.key.canMatchDeclaration();
-    });
-    m_strategy = matchDeclarations ? VisitorStrategy::ByFunctionDeclaration
-                                   : VisitorStrategy::ByInstruction;
+  if (key.m_kind == VisitorKey::Kind::Intrinsic) {
+    m_intrinsicIdMap[key.m_intrinsicId].push_back(handlerIdx);
+  } else {
+    const OpDescription *description = key.m_description;
+    switch (description->getKind()) {
+    case OpDescription::Kind::Core:
+      for (unsigned opcode : description->getOpcodes())
+        m_coreOpcodeMap[opcode].push_back(handlerIdx);
+      break;
+    case OpDescription::Kind::Intrinsic:
+      for (unsigned id : description->getOpcodes())
+        m_intrinsicIdMap[id].push_back(handlerIdx);
+      break;
+    default: {
+      auto it = find_if(m_dialectCases, [=](const auto &theCase) {
+        return theCase.first == description;
+      });
+      if (it != m_dialectCases.end()) {
+        it->second.push_back(handlerIdx);
+      } else {
+        SmallVector<unsigned> handlers;
+        handlers.push_back(handlerIdx);
+        m_dialectCases.emplace_back(description, std::move(handlers));
+      }
+      break;
+    }
+    }
   }
 }
 
-void VisitorBase::call(const VisitorCase &theCase, void *payload,
-                       Instruction &inst) const {
-  if (theCase.projection >= 0) {
-    payload = (char *)payload + theCase.projection;
+VisitorBuilderBase::VisitorBuilderBase()
+    : m_template(&m_ownedTemplate), m_projection(0) {}
+
+VisitorBuilderBase::VisitorBuilderBase(VisitorBuilderBase *parent,
+                                       PayloadProjectionCallback *projection)
+    : m_template(parent->m_template) {
+  // Extract and update the parent's projection.
+  SmallVector<PayloadProjection> sequence;
+
+  if (parent->m_projection >= 0) {
+    sequence.emplace_back();
+    sequence.back().offset = parent->m_projection;
   } else {
-    for (size_t idx = -theCase.projection - 1;; ++idx) {
+    for (size_t idx = -parent->m_projection - 1;; ++idx) {
+      sequence.push_back(m_template->m_projections[idx]);
+      if (!sequence.back().projection)
+        break;
+    }
+  }
+
+  sequence.back().projection = projection;
+  sequence.emplace_back();
+
+  // Setup our projection.
+  m_projection = -(m_template->m_projections.size() + 1);
+  m_template->m_projections.insert(m_template->m_projections.end(),
+                                   sequence.begin(), sequence.end());
+}
+
+VisitorBuilderBase::VisitorBuilderBase(VisitorBuilderBase *parent,
+                                       size_t offset)
+    : m_template(parent->m_template) {
+  if (offset == 0) {
+    m_projection = parent->m_projection;
+  } else if (parent->m_projection >= 0) {
+    m_projection = parent->m_projection + offset;
+  } else {
+    // Extract and update the parent's projection.
+    SmallVector<PayloadProjection> sequence;
+    for (size_t idx = -parent->m_projection - 1;; ++idx) {
+      sequence.push_back(m_template->m_projections[idx]);
+      if (!sequence.back().projection)
+        break;
+    }
+    sequence.back().offset += offset;
+
+    // Setup our projection.
+    m_projection = -(m_template->m_projections.size() + 1);
+    m_template->m_projections.insert(m_template->m_projections.end(),
+                                     sequence.begin(), sequence.end());
+  }
+}
+
+void VisitorBuilderBase::setStrategy(VisitorStrategy strategy) {
+  m_template->setStrategy(strategy);
+}
+
+void VisitorBuilderBase::add(VisitorKey key, void *extra, VisitorCallback *fn) {
+  m_template->add(key, extra, fn, m_projection);
+}
+
+VisitorBase VisitorBuilderBase::build() {
+  assert(m_template == &m_ownedTemplate);
+  return std::move(m_ownedTemplate);
+}
+
+class VisitorBase::BuildHelper {
+public:
+  BuildHelper(VisitorBase &self, ArrayRef<VisitorHandler> srcHandlers)
+      : m_srcHandlers(srcHandlers), m_dstHandlers(self.m_handlers) {}
+
+  HandlerRange mapHandlers(ArrayRef<unsigned> handlers) {
+    auto it = m_handlerMap.find(handlers);
+    if (it != m_handlerMap.end())
+      return it->second;
+
+    HandlerRange range;
+    range.first = m_dstHandlers.size();
+    range.second = range.first + handlers.size();
+
+    for (unsigned srcIdx : handlers)
+      m_dstHandlers.push_back(m_srcHandlers[srcIdx]);
+
+    m_handlerMap.try_emplace(handlers, range);
+    return range;
+  }
+
+private:
+  ArrayRef<VisitorHandler> m_srcHandlers;
+  std::vector<VisitorHandler> &m_dstHandlers;
+  DenseMap<ArrayRef<unsigned>, HandlerRange> m_handlerMap;
+};
+
+VisitorBase::VisitorBase(VisitorTemplate &&templ)
+    : m_strategy(templ.m_strategy),
+      m_projections(std::move(templ.m_projections)) {
+  if (m_strategy == VisitorStrategy::Default) {
+    m_strategy = templ.m_coreOpcodeMap.empty()
+                     ? VisitorStrategy::ByFunctionDeclaration
+                     : VisitorStrategy::ByInstruction;
+  }
+
+  BuildHelper helper(*this, templ.m_handlers);
+
+  m_coreOpcodeMap.reserve(templ.m_coreOpcodeMap.size());
+  m_intrinsicIdMap.reserve(templ.m_intrinsicIdMap.size());
+  m_dialectCases.reserve(templ.m_dialectCases.size());
+
+  for (const auto &entry : templ.m_coreOpcodeMap) {
+    m_coreOpcodeMap.try_emplace(entry.first, helper.mapHandlers(entry.second));
+  }
+  for (const auto &entry : templ.m_intrinsicIdMap) {
+    m_intrinsicIdMap.try_emplace(entry.first, helper.mapHandlers(entry.second));
+  }
+  for (const auto &entry : templ.m_dialectCases) {
+    m_dialectCases.emplace_back(entry.first, helper.mapHandlers(entry.second));
+  }
+}
+
+void VisitorBase::call(HandlerRange handlers, void *payload,
+                       Instruction &inst) const {
+  for (unsigned idx = handlers.first; idx != handlers.second; ++idx)
+    call(m_handlers[idx], payload, inst);
+}
+
+void VisitorBase::call(const VisitorHandler &handler, void *payload,
+                       Instruction &inst) const {
+  if (handler.projection >= 0) {
+    payload = (char *)payload + handler.projection;
+  } else {
+    for (size_t idx = -handler.projection - 1;; ++idx) {
       payload = (char *)payload + m_projections[idx].offset;
       if (!m_projections[idx].projection)
         break;
       payload = m_projections[idx].projection(payload);
     }
   }
-  theCase.callback(theCase.callbackData, payload, &inst);
+  handler.callback(handler.callbackData, payload, &inst);
 }
 
 void VisitorBase::visit(void *payload, Instruction &inst) const {
-  for (const auto &theCase : m_cases) {
-    if (theCase.key.matchInstruction(inst))
-      call(theCase, payload, inst);
+  if (auto *callInst = dyn_cast<CallInst>(&inst)) {
+    // Note: Always fall through to case handlers installed for generic
+    // CallInst instructions, if there are any.
+    if (auto *intrinsicInst = dyn_cast<IntrinsicInst>(callInst)) {
+      auto it = m_intrinsicIdMap.find(intrinsicInst->getIntrinsicID());
+      if (it != m_intrinsicIdMap.end())
+        call(it->second, payload, inst);
+    } else {
+      for (const auto &theCase : m_dialectCases) {
+        if (theCase.first->matchInstruction(inst)) {
+          call(theCase.second, payload, inst);
+          break;
+        }
+      }
+    }
+  }
+
+  auto it = m_coreOpcodeMap.find(inst.getOpcode());
+  if (it != m_coreOpcodeMap.end())
+    call(it->second, payload, inst);
+}
+
+template <typename FilterT>
+void VisitorBase::visitByDeclarations(void *payload, llvm::Module &module,
+                                      FilterT &&filter) const {
+  assert(m_strategy == VisitorStrategy::ByFunctionDeclaration);
+
+  for (Function &decl : module.functions()) {
+    if (!decl.isDeclaration())
+      continue;
+
+    LLVM_DEBUG(dbgs() << "visit " << decl.getName() << '\n');
+
+    HandlerRange handlers{0, 0};
+    if (unsigned intrinsicId = decl.getIntrinsicID()) {
+      auto it = m_intrinsicIdMap.find(intrinsicId);
+      if (it == m_intrinsicIdMap.end()) {
+        // Can't be a dialect op, so skip this declaration entirely.
+        continue;
+      }
+      handlers = it->second;
+    }
+
+    if (handlers.second == 0) {
+      for (const auto &theCase : m_dialectCases) {
+        if (theCase.first->matchDeclaration(decl)) {
+          handlers = theCase.second;
+          break;
+        }
+      }
+    }
+
+    if (handlers.second == 0) {
+      // Neither a matched intrinsic nor a matched dialect op; skip.
+      continue;
+    }
+
+    for (Use &use : decl.uses()) {
+      if (auto *inst = dyn_cast<Instruction>(use.getUser())) {
+        if (!filter(*inst))
+          continue;
+        if (auto *callInst = dyn_cast<CallInst>(inst)) {
+          if (&use == &callInst->getCalledOperandUse())
+            call(handlers, payload, *callInst);
+        }
+      }
+    }
   }
 }
 
@@ -156,27 +312,9 @@ void VisitorBase::visit(void *payload, Function &fn) const {
     return;
   }
 
-  for (Function &decl : fn.getParent()->functions()) {
-    if (!decl.isDeclaration())
-      continue;
-
-    LLVM_DEBUG(dbgs() << "visit " << decl.getName() << '\n');
-
-    for (const auto &theCase : m_cases) {
-      if (theCase.key.matchDeclaration(decl)) {
-        for (Use &use : decl.uses()) {
-          if (auto *inst = dyn_cast<Instruction>(use.getUser())) {
-            if (inst->getFunction() != &fn)
-              continue;
-            if (auto *callInst = dyn_cast<CallInst>(inst)) {
-              if (&use == &callInst->getCalledOperandUse())
-                call(theCase, payload, *callInst);
-            }
-          }
-        }
-      }
-    }
-  }
+  visitByDeclarations(payload, *fn.getParent(), [&fn](Instruction &inst) {
+    return inst.getFunction() == &fn;
+  });
 }
 
 void VisitorBase::visit(void *payload, Module &module) const {
@@ -188,19 +326,5 @@ void VisitorBase::visit(void *payload, Module &module) const {
     return;
   }
 
-  for (Function &decl : module.functions()) {
-    if (!decl.isDeclaration())
-      continue;
-
-    for (const auto &theCase : m_cases) {
-      if (theCase.key.matchDeclaration(decl)) {
-        for (Use &use : decl.uses()) {
-          if (auto *callInst = dyn_cast<CallInst>(use.getUser())) {
-            if (&use == &callInst->getCalledOperandUse())
-              call(theCase, payload, *callInst);
-          }
-        }
-      }
-    }
-  }
+  visitByDeclarations(payload, module, [](Instruction &inst) { return true; });
 }

--- a/test/example/visitor-basic.ll
+++ b/test/example/visitor-basic.ll
@@ -1,0 +1,17 @@
+; RUN: llvm-dialects-example -visit %s | FileCheck --check-prefixes=DEFAULT %s
+
+; DEFAULT-DAG: visiting ReadOp: %v = call i32 @xd.read.i32()
+; DEFAULT-DAG: visiting WriteOp: call void (...) @xd.write(i8 %t)
+; DEFAULT: inner.counter = 1
+
+define void @test1(ptr %p) {
+entry:
+  %v = call i32 @xd.read.i32()
+  %t = call i8 (...) @xd.itrunc.i8(i32 %v)
+  call void (...) @xd.write(i8 %t)
+  ret void
+}
+
+declare i32 @xd.read.i32()
+declare void @xd.write(...)
+declare i8 @xd.itrunc.i8(...)

--- a/test/example/visitor-basic.ll
+++ b/test/example/visitor-basic.ll
@@ -1,13 +1,23 @@
 ; RUN: llvm-dialects-example -visit %s | FileCheck --check-prefixes=DEFAULT %s
 
-; DEFAULT-DAG: visiting ReadOp: %v = call i32 @xd.read.i32()
-; DEFAULT-DAG: visiting WriteOp: call void (...) @xd.write(i8 %t)
-; DEFAULT: inner.counter = 1
+; DEFAULT: visiting ReadOp: %v = call i32 @xd.read.i32()
+; DEFAULT-NEXT: visiting UnaryInstruction: %w = load i32, ptr %p
+; DEFAULT-NEXT: visiting UnaryInstruction: %q = load i32, ptr %p1
+; DEFAULT-NEXT: visiting BinaryOperator: %v1 = add i32 %v, %w
+; DEFAULT-NEXT: visiting umax intrinsic: %v2 = call i32 @llvm.umax.i32(i32 %v1, i32 %q)
+; DEFAULT-NEXT: visiting WriteOp: call void (...) @xd.write(i8 %t)
+; DEFAULT-NEXT: visiting ReturnInst: ret void
+; DEFAULT-NEXT: inner.counter = 1
 
 define void @test1(ptr %p) {
 entry:
   %v = call i32 @xd.read.i32()
-  %t = call i8 (...) @xd.itrunc.i8(i32 %v)
+  %w = load i32, ptr %p
+  %p1 = getelementptr i32, ptr %p, i32 1
+  %q = load i32, ptr %p1
+  %v1 = add i32 %v, %w
+  %v2 = call i32 @llvm.umax.i32(i32 %v1, i32 %q)
+  %t = call i8 (...) @xd.itrunc.i8(i32 %v2)
   call void (...) @xd.write(i8 %t)
   ret void
 }
@@ -15,3 +25,5 @@ entry:
 declare i32 @xd.read.i32()
 declare void @xd.write(...)
 declare i8 @xd.itrunc.i8(...)
+
+declare i32 @llvm.umax.i32(i32, i32)

--- a/test/example/visitor-rpot.ll
+++ b/test/example/visitor-rpot.ll
@@ -1,0 +1,26 @@
+; RUN: llvm-dialects-example -visit %s | FileCheck --check-prefixes=DEFAULT %s
+; RUN: llvm-dialects-example -visit -rpot %s | FileCheck --check-prefixes=RPOT %s
+
+; DEFAULT: visiting WriteOp: call void (...) @xd.write(i32 0)
+; DEFAULT: visiting WriteOp: call void (...) @xd.write(i32 2)
+; DEFAULT: visiting WriteOp: call void (...) @xd.write(i32 1)
+
+; RPOT: visiting WriteOp: call void (...) @xd.write(i32 0)
+; RPOT: visiting WriteOp: call void (...) @xd.write(i32 1)
+; RPOT: visiting WriteOp: call void (...) @xd.write(i32 2)
+
+define void @test1(ptr %p) {
+entry:
+  call void (...) @xd.write(i32 0)
+  br label %a
+
+b:
+  call void (...) @xd.write(i32 2)
+  ret void
+
+a:
+  call void (...) @xd.write(i32 1)
+  br label %b
+}
+
+declare void @xd.write(...)


### PR DESCRIPTION
The overall goal here is to have a unified framework for visiting instructions, whether they're dialect ops or core instructions, plus then a bunch of convenience features.

* Visitor: Add support for nested visitor clients
* Visitor: Add VisitorStrategy::ReversePostOrder
* Visitor: allow visiting core instructions and intrinsics
* Visitor: Optimize core opcode and intrinsic ID lookup
* Visitor: Add convenient way of using member functions
