### PR TITLE
Fix vararg getter

### DIFF
--- a/example/ExampleMain.cpp
+++ b/example/ExampleMain.cpp
@@ -121,19 +121,7 @@ void createFunctionExample(Module &module, const Twine &name) {
   SmallVector<Value *> varArgs;
   varArgs.push_back(p1);
   varArgs.push_back(p2);
-  xd::WriteVarArgOp *w = b.create<xd::WriteVarArgOp>(p2, varArgs);
-  assert(w->getData() == p2);
-  assert(w->getData()->getName() == "p2");
-
-  const auto &itRange = w->getArgs();
-  assert(!itRange.empty());
-  xd::WriteOp *w2 = b.create<xd::WriteOp>(itRange.begin());
-  xd::WriteOp *w3 = b.create<xd::WriteOp>(itRange.end());
-
-  assert(w2->getData() == p1);
-  assert(w2->getData()->getName() == "p1");
-  assert(w3->getData() == p2);
-  assert(w3->getData()->getName() == "p2");
+  b.create<xd::WriteVarArgOp>(p2, varArgs);
   b.create<xd::HandleGetOp>();
 
   useUnnamedStructTypes(b);
@@ -215,7 +203,9 @@ template <bool rpot> const Visitor<VisitorContainer> &getExampleVisitor() {
               });
               b.add<xd::WriteVarArgOp>(
                   [](raw_ostream &out, xd::WriteVarArgOp &op) {
-                    out << "visiting WriteVarArgOp: " << op << '\n';
+                    out << "visiting WriteVarArgOp: " << op << ":\n";
+                    for (Value *arg : op.getArgs())
+                      out << "  " << *arg << '\n';
                   });
               b.add<ReturnInst>([](raw_ostream &out, ReturnInst &ret) {
                 out << "visiting ReturnInst: " << ret << '\n';

--- a/include/llvm-dialects/Dialect/Utils.h
+++ b/include/llvm-dialects/Dialect/Utils.h
@@ -18,7 +18,9 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/iterator.h"
 #include "llvm/IR/Type.h"
+#include "llvm/IR/User.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {

--- a/lib/TableGen/Constraints.cpp
+++ b/lib/TableGen/Constraints.cpp
@@ -312,7 +312,7 @@ StringRef MetaType::getGetterCppType() const {
     return "::llvm::Value *";
 
   if (isVarArgList())
-    return "::llvm::iterator_range<::llvm::Value *>";
+    return "::llvm::iterator_range<::llvm::User::value_op_iterator>";
 
   return getCppType();
 }

--- a/lib/TableGen/Operations.cpp
+++ b/lib/TableGen/Operations.cpp
@@ -188,9 +188,11 @@ void AccessorBuilder::emitGetterDefinition() const {
     else if (m_arg.type->isTypeArg())
       fromLlvm += "->getType()";
   } else {
-    fromLlvm = tgfmt("::llvm::make_range((arg_begin() + $index)->get(), "
-                     "(arg_begin() + arg_size() - $index)->get())",
-                     &m_fmt);
+    fromLlvm = tgfmt(
+        R"(::llvm::make_range(
+            value_op_iterator(arg_begin() + $index),
+            value_op_iterator(arg_end())))",
+        &m_fmt);
   }
 
   m_fmt.addSubst("fromLlvm", fromLlvm);

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -1671,8 +1671,10 @@ data
       void WriteVarArgOp::setData(::llvm::Value * data) {
         setArgOperand(0, data);
       }
-      ::llvm::iterator_range<::llvm::Value *> WriteVarArgOp::getArgs() {
-        return ::llvm::make_range((arg_begin() + 1)->get(), (arg_begin() + arg_size() - 1)->get());
+      ::llvm::iterator_range<::llvm::User::value_op_iterator> WriteVarArgOp::getArgs() {
+        return ::llvm::make_range(
+            value_op_iterator(arg_begin() + 1),
+            value_op_iterator(arg_end()));
       }
 
 

--- a/test/example/generated/ExampleDialect.h.inc
+++ b/test/example/generated/ExampleDialect.h.inc
@@ -444,7 +444,7 @@ bool verifier(::llvm::raw_ostream &errs);
 
 ::llvm::Value * getData();
         void setData(::llvm::Value * data);
-      ::llvm::iterator_range<::llvm::Value *> getArgs();
+      ::llvm::iterator_range<::llvm::User::value_op_iterator> getArgs();
 
 
       };

--- a/test/example/test-builder.test
+++ b/test/example/test-builder.test
@@ -25,8 +25,6 @@
 ; CHECK-NEXT:    [[P2:%.*]] = call i8 (...) @xd.stream.add.i8(ptr [[P1]], i64 14, i8 0)
 ; CHECK-NEXT:    call void (...) @xd.write(i8 [[P2]])
 ; CHECK-NEXT:    call void (...) @xd.write.vararg(i8 [[P2]], ptr [[P1]], i8 [[P2]])
-; CHECK-NEXT:    call void (...) @xd.write(ptr [[P1]])
-; CHECK-NEXT:    call void (...) @xd.write(i8 [[P2]])
 ; CHECK-NEXT:    [[TMP14:%.*]] = call target("xd.handle") @xd.handle.get()
 ; CHECK-NEXT:    [[TMP15:%.*]] = call [[TMP0]] @xd.read.s_s()
 ; CHECK-NEXT:    [[TMP16:%.*]] = call [[TMP1]] @xd.read.s_s_0()

--- a/test/example/visitor-basic.ll
+++ b/test/example/visitor-basic.ll
@@ -6,7 +6,9 @@
 ; DEFAULT-NEXT: visiting BinaryOperator: %v1 = add i32 %v, %w
 ; DEFAULT-NEXT: visiting umax intrinsic: %v2 = call i32 @llvm.umax.i32(i32 %v1, i32 %q)
 ; DEFAULT-NEXT: visiting WriteOp: call void (...) @xd.write(i8 %t)
-; DEFAULT-NEXT: visiting WriteVarArgOp: call void (...) @xd.write.vararg(i8 %t, i32 %v2)
+; DEFAULT-NEXT: visiting WriteVarArgOp: call void (...) @xd.write.vararg(i8 %t, i32 %v2, i32 %q)
+; DEFAULT-NEXT:   %v2 =
+; DEFAULT-NEXT:   %q =
 ; DEFAULT-NEXT: visiting ReturnInst: ret void
 ; DEFAULT-NEXT: inner.counter = 1
 
@@ -20,7 +22,7 @@ entry:
   %v2 = call i32 @llvm.umax.i32(i32 %v1, i32 %q)
   %t = call i8 (...) @xd.itrunc.i8(i32 %v2)
   call void (...) @xd.write(i8 %t)
-  call void (...) @xd.write.vararg(i8 %t, i32 %v2)
+  call void (...) @xd.write.vararg(i8 %t, i32 %v2, i32 %q)
   ret void
 }
 


### PR DESCRIPTION
arg_begin() and arg_end() return iterators over Use objects that are stored contiguously in memory, but the Value objects that the uses point to are very much not contiguous.

We solve this by introducing an iterator adaptor. The example code is also adjusted to test this in a better way.