### PR TITLE
Include <variant>

### DIFF
--- a/include/llvm-dialects/Dialect/OpDescription.h
+++ b/include/llvm-dialects/Dialect/OpDescription.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
+#include <variant>
 #include <vector>
 
 namespace llvm {


### PR DESCRIPTION
After LLVM patch https://reviews.llvm.org/D150997, `<variant>` is no longer included transitively here.