### PR TITLE
Add const to match{Declaration,Instruction} function arguments

### DIFF
--- a/include/llvm-dialects/Dialect/OpDescription.h
+++ b/include/llvm-dialects/Dialect/OpDescription.h
@@ -52,8 +52,8 @@ public:
   Kind getKind() const { return m_kind; }
   llvm::ArrayRef<unsigned> getOpcodes() const;
 
-  bool matchInstruction(llvm::Instruction &inst) const;
-  bool matchDeclaration(llvm::Function &decl) const;
+  bool matchInstruction(const llvm::Instruction &inst) const;
+  bool matchDeclaration(const llvm::Function &decl) const;
 
   bool canMatchDeclaration() const {
     return m_kind == Kind::Dialect || m_kind == Kind::DialectWithOverloads ||

--- a/lib/Dialect/OpDescription.cpp
+++ b/lib/Dialect/OpDescription.cpp
@@ -39,7 +39,7 @@ ArrayRef<unsigned> OpDescription::getOpcodes() const {
   return std::get<ArrayRef<unsigned>>(m_op);
 }
 
-bool OpDescription::matchInstruction(Instruction &inst) const {
+bool OpDescription::matchInstruction(const Instruction &inst) const {
   if (m_kind == Kind::Intrinsic) {
     if (auto *intr = dyn_cast<IntrinsicInst>(&inst))
       return matchIntrinsic(intr->getIntrinsicID());
@@ -62,7 +62,7 @@ bool OpDescription::matchInstruction(Instruction &inst) const {
   return false;
 }
 
-bool OpDescription::matchDeclaration(Function &decl) const {
+bool OpDescription::matchDeclaration(const Function &decl) const {
   if (auto *mnemonic = std::get_if<StringRef>(&m_op)) {
     if (m_kind == Kind::DialectWithOverloads)
       return llvm_dialects::detail::isOverloadedOperationDecl(&decl, *mnemonic);


### PR DESCRIPTION
Logically, this operation should not need to change the passed object (Instruction or Function), and indeed the implementation needs only `const` access.