### PR TITLE
Include StringExtras.h

### DIFF
--- a/lib/TableGen/GenDialect.cpp
+++ b/lib/TableGen/GenDialect.cpp
@@ -231,6 +231,7 @@ void llvm_dialects::genDialectDefs(raw_ostream& out, RecordKeeper& records) {
 #include "llvm-dialects/Dialect/Visitor.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/InstrTypes.h"
 )";
 

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -10,6 +10,7 @@
 #include "llvm-dialects/Dialect/Visitor.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/InstrTypes.h"
 
 #include "llvm/Support/ModRef.h"


### PR DESCRIPTION
After LLVM patch https://reviews.llvm.org/D155018, StringExtras.h is no longer included transitively.