### PR TITLE
Move Operation constructor to .cpp

### DIFF
--- a/include/llvm-dialects/TableGen/Operations.h
+++ b/include/llvm-dialects/TableGen/Operations.h
@@ -106,7 +106,7 @@ public:
 
   std::vector<NamedValue> results;
 
-  Operation(GenDialectsContext &context) : m_system(context, m_scope) {}
+  Operation(GenDialectsContext &context);
   ~Operation();
 
   static bool parse(llvm::raw_ostream &errs, GenDialectsContext *context,

--- a/lib/TableGen/Operations.cpp
+++ b/lib/TableGen/Operations.cpp
@@ -285,6 +285,9 @@ static std::string evaluateAttrLlvmType(raw_ostream &errs, raw_ostream &out,
   return attrType;
 }
 
+// Implement constructor here, where BuilderMethod is fully defined.
+Operation::Operation(GenDialectsContext &context) : m_system(context, m_scope) {}
+
 // Default destructor instantiated explicitly to avoid having to add more
 // includes in the header.
 Operation::~Operation() = default;


### PR DESCRIPTION
clang 16 fails compilation because BuilderMethod was not yet completely defined but the std::vector<BuilderMethod> was initialized in this constructor.

Moving the implementation to after BuilderMethod is defined fixes that.

Error message:
```
stl_vector.h:367:35: error: arithmetic on a pointer to an incomplete type 'llvm_dialects::BuilderMethod'
                      _M_impl._M_end_of_storage - _M_impl._M_start);
                      ~~~~~~~~~~~~~~~~~~~~~~~~~ ^
stl_vector.h:526:7: note: in instantiation of member function 'std::_Vector_base<llvm_dialects::BuilderMethod, std::allocator<llvm_dialects::BuilderMethod>>::~_Vector_base' requested here
      vector() = default;
      ^
include/llvm-dialects/TableGen/Operations.h:109:3: note: in defaulted default constructor for 'std::vector<llvm_dialects::BuilderMethod>' first required here
  Operation(GenDialectsContext &context) : m_system(context, m_scope) {}
  ^
include/llvm-dialects/TableGen/Operations.h:34:7: note: forward declaration of 'llvm_dialects::BuilderMethod'
class BuilderMethod;
```