### PR TITLE
tablegen: relax a restriction of logic or

### DIFF
--- a/include/llvm-dialects/TableGen/Constraints.h
+++ b/include/llvm-dialects/TableGen/Constraints.h
@@ -85,11 +85,18 @@ private:
   bool addConstraintImpl(llvm::raw_ostream &errs, llvm::Init *init,
                          Variable *self);
   void addVariable(Variable *variable);
+  void addGlobalVariable(Variable *variable);
 
   GenDialectsContext &m_context;
   Scope &m_scope;
   std::vector<std::unique_ptr<Constraint>> m_constraints;
+
+  // List of all free variables that appear in the constraint system.
   std::vector<Variable *> m_variables;
+
+  // List of all free variables that appear in the constraint system and that
+  // may be referenced from the outside.
+  std::vector<Variable *> m_globalVariables;
 };
 
 class Constraint {

--- a/test/tablegen/logic-or-free-variables.td
+++ b/test/tablegen/logic-or-free-variables.td
@@ -1,0 +1,27 @@
+// RUN: llvm-dialects-tblgen -gen-dialect-defs -dialect=test -I%S/../../include %s 2>&1 | FileCheck --check-prefixes=CHECK %s
+
+// Only check that the generation runs through without error.
+
+// CHECK: #endif // GET_DIALECT_DEFS
+
+include "llvm-dialects/Dialect/Dialect.td"
+
+def TestDialect : Dialect {
+  let name = "test";
+  let cppNamespace = "test";
+}
+
+def TestOp : Op<TestDialect, "test", []> {
+  let results = (outs);
+  let arguments = (ins value:$x);
+
+  let verifier = [
+    (or (I32 $x), (FixedVectorType $x, I32, any)),
+  ];
+
+  let summary = "add two integers or vectors of integers";
+  let description = [{
+    Demonstrates that a TgConstant can be used inside of a logic or constraint
+    and won't be treated as a free variable.
+  }];
+}


### PR DESCRIPTION
The constraint system evaluator refuses to evaluate a logic or unless
all variables that appear in it have been resolved. This is a good
thing, because we can't reliably capture variables from inside a logic
or.

However, the check was too restrictive since it also refused to evaluate
a logic or that contain a local/internal variable that is introduced
purely as a connective between "apply" constraints that appear as nested
tablegen DAGs.

We relax this restriction by making the distinction between "global" and
"non-global" variables explicit.