### PR TITLE
[CI] Fix sanitizer builds

### DIFF
--- a/.github/workflows/check-dialects-docker.yml
+++ b/.github/workflows/check-dialects-docker.yml
@@ -16,8 +16,8 @@ jobs:
         config:              [Release]
         feature-set:         ["+gcc", "+gcc+assertions",
                               "+clang",
-                              "+clang+shadercache+ubsan+asan",
-                              "+clang+shadercache+ubsan+asan+assertions"]
+                              "+clang+ubsan+asan",
+                              "+clang+ubsan+asan+assertions"]
     steps:
       - name: Free up disk space
         if: contains(matrix.feature-set, '+ubsan') || contains(matrix.feature-set, '+asan') || contains(matrix.feature-set, '+tsan') || contains(matrix.feature-set, '+coverage')


### PR DESCRIPTION
The +shadercache builds have been retired in llpc, so we also need to switch to the pure clang+sanitizers builds.

Fixes CI failures on the sanitizer builds.