### PR TITLE
[OpMap] Fix GCC compiler warnings.

### DIFF
--- a/example/ExampleMain.cpp
+++ b/example/ExampleMain.cpp
@@ -191,9 +191,9 @@ template <bool rpot> const Visitor<VisitorContainer> &getExampleVisitor() {
                 });
             b.addSet(complexSet, [](VisitorNest &self, llvm::Instruction &op) {
               assert((op.getOpcode() == Instruction::Ret ||
-                      (isa<IntrinsicInst>)(&op) &&
+                      (isa<IntrinsicInst>(&op) &&
                           cast<IntrinsicInst>(&op)->getIntrinsicID() ==
-                              Intrinsic::umin) &&
+                              Intrinsic::umin)) &&
                      "Unexpected operation detected while visiting OpSet!");
 
               if (op.getOpcode() == Instruction::Ret) {


### PR DESCRIPTION
GCC spotted the following warnings:

a) Parenthesis usage around assert in complexSet is not correct in ExampleMain
b) OpMap::m_dialectOps uses the anonymous namespace indirectly (-Wsubobject-linkage)