### PR TITLE
Support LLVM15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(llvm-dialects)
 
 # Options intended for configuration by the user:
 #  - CMAKE_BUILD_TYPE
-#  - LLVM_DIR
+#  - LLVM_ROOT
 #
 # The build system is intended to be usable both as an external subproject of
 # the llvm-project build tree, and as a separate subdirectory / subproject.

--- a/lib/Dialect/OpDescription.cpp
+++ b/lib/Dialect/OpDescription.cpp
@@ -145,17 +145,27 @@ template <> const OpDescription &OpDescription::get<BinaryOperator>() {
 // ============================================================================
 // Descriptions of intrinsic facades implemented in LLVM
 
+
+#if HAVE_LLVM_VERSION_MAJOR >= 16
 HANDLE_INTRINSIC_DESC_OPCODE_SET(LifetimeIntrinsic, Intrinsic::lifetime_start,
                                  Intrinsic::lifetime_end)
+#endif
 
 // Add Intrinsic::dbg_addr back for sufficiently recent LLVM
 HANDLE_INTRINSIC_DESC_OPCODE_SET(DbgInfoIntrinsic, Intrinsic::dbg_declare,
-                                 Intrinsic::dbg_value, Intrinsic::dbg_label,
-                                 Intrinsic::dbg_assign)
+                                 Intrinsic::dbg_value, Intrinsic::dbg_label
+#if HAVE_LLVM_VERSION_MAJOR >= 16
+                                 ,Intrinsic::dbg_assign
+#endif
+                                 )
 
 // Add Intrinsic::dbg_addr back for sufficiently recent LLVM
 HANDLE_INTRINSIC_DESC_OPCODE_SET(DbgVariableIntrinsic, Intrinsic::dbg_declare,
-                                 Intrinsic::dbg_value, Intrinsic::dbg_assign)
+                                 Intrinsic::dbg_value
+#if HAVE_LLVM_VERSION_MAJOR >= 16
+                                 ,Intrinsic::dbg_assign
+#endif
+                                )
 
 HANDLE_INTRINSIC_DESC(DbgDeclareInst, dbg_declare)
 HANDLE_INTRINSIC_DESC(DbgValueInst, dbg_value)
@@ -163,7 +173,9 @@ HANDLE_INTRINSIC_DESC(DbgValueInst, dbg_value)
 // Add this back for sufficiently recent LLVM
 // HANDLE_INTRINSIC_DESC(DbgAddrIntrinsic, dbg_addr)
 
+#if HAVE_LLVM_VERSION_MAJOR >= 16
 HANDLE_INTRINSIC_DESC(DbgAssignIntrinsic, dbg_assign)
+#endif
 HANDLE_INTRINSIC_DESC(DbgLabelInst, dbg_label)
 
 HANDLE_INTRINSIC_DESC_OPCODE_SET(AtomicMemIntrinsic,

--- a/lib/Dialect/Utils.cpp
+++ b/lib/Dialect/Utils.cpp
@@ -26,7 +26,11 @@ using namespace llvm;
 using namespace llvm_dialects;
 
 bool llvm_dialects::areTypesEqual(ArrayRef<Type *> types) {
+#if HAVE_LLVM_VERSION_MAJOR >= 16
   return llvm::all_equal(types);
+#else
+  return llvm::is_splat(types);
+#endif
 }
 
 // The following function is copied verbatim from


### PR DESCRIPTION
Considering https://github.com/GPUOpen-Drivers/llvm-dialects/issues/68#issuecomment-1777709242 I was trying to see
what it would take to compile llvm-dialects for LLVM 15.

Right now I am hitting

```
[  4%] Building CXX object CMakeFiles/llvm_dialects.dir/lib/Dialect/OpDescription.cpp.o
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp:148:34: error: ‘LifetimeIntrinsic’ was not declared in this scope
  148 | HANDLE_INTRINSIC_DESC_OPCODE_SET(LifetimeIntrinsic, Intrinsic::lifetime_start,
      |                                  ^~~~~~~~~~~~~~~~~
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp:139:55: note: in definition of macro ‘HANDLE_INTRINSIC_DESC_OPCODE_SET’
  139 |   template <> const OpDescription &OpDescription::get<Class>() {               \
      |                                                       ^~~~~
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp:139:36: error: template-id ‘get<<expression error> >’ for ‘const llvm_dialects::OpDescription& llvm_dialects::OpDescription::get()’ does not match any template declaration
  139 |   template <> const OpDescription &OpDescription::get<Class>() {               \
      |                                    ^~~~~~~~~~~~~
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp:148:1: note: in expansion of macro ‘HANDLE_INTRINSIC_DESC_OPCODE_SET’
  148 | HANDLE_INTRINSIC_DESC_OPCODE_SET(LifetimeIntrinsic, Intrinsic::lifetime_start,
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp:17:
/home/vchuravy/src/llvm-dialects/include/llvm-dialects/Dialect/OpDescription.h:66:55: note: candidate is: ‘template<class OpT> static const llvm_dialects::OpDescription& llvm_dialects::OpDescription::get()’
   66 |   template <typename OpT> static const OpDescription &get();
      |                                                       ^~~
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp: In static member function ‘static const llvm_dialects::OpDescription& llvm_dialects::OpDescription::get() [with OpT = llvm::DbgInfoIntrinsic]’:
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp:154:45: error: ‘dbg_assign’ is not a member of ‘llvm::Intrinsic’
  154 |                                  Intrinsic::dbg_assign)
      |                                             ^~~~~~~~~~
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp:140:34: note: in definition of macro ‘HANDLE_INTRINSIC_DESC_OPCODE_SET’
  140 |     static unsigned opcodes[] = {__VA_ARGS__};                                 \
      |                                  ^~~~~~~~~~~
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp: In static member function ‘static const llvm_dialects::OpDescription& llvm_dialects::OpDescription::get() [with OpT = llvm::DbgVariableIntrinsic]’:
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp:158:67: error: ‘dbg_assign’ is not a member of ‘llvm::Intrinsic’
  158 |                                  Intrinsic::dbg_value, Intrinsic::dbg_assign)
      |                                                                   ^~~~~~~~~~
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp:140:34: note: in definition of macro ‘HANDLE_INTRINSIC_DESC_OPCODE_SET’
  140 |     static unsigned opcodes[] = {__VA_ARGS__};                                 \
      |                                  ^~~~~~~~~~~
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp: At global scope:
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp:166:23: error: ‘DbgAssignIntrinsic’ was not declared in this scope
  166 | HANDLE_INTRINSIC_DESC(DbgAssignIntrinsic, dbg_assign)
      |                       ^~~~~~~~~~~~~~~~~~
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp:134:55: note: in definition of macro ‘HANDLE_INTRINSIC_DESC’
  134 |   template <> const OpDescription &OpDescription::get<Class>() {               \
      |                                                       ^~~~~
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp:134:36: error: template-id ‘get<<expression error> >’ for ‘const llvm_dialects::OpDescription& llvm_dialects::OpDescription::get()’ does not match any template declaration
  134 |   template <> const OpDescription &OpDescription::get<Class>() {               \
      |                                    ^~~~~~~~~~~~~
/home/vchuravy/src/llvm-dialects/lib/Dialect/OpDescription.cpp:166:1: note: in expansion of macro ‘HANDLE_INTRINSIC_DESC’
  166 | HANDLE_INTRINSIC_DESC(DbgAssignIntrinsic, dbg_assign)
      | ^~~~~~~~~~~~~~~~~~~~~
/home/vchuravy/src/llvm-dialects/include/llvm-dialects/Dialect/OpDescription.h:66:55: note: candidate is: ‘template<class OpT> static const llvm_dialects::OpDescription& llvm_dialects::OpDescription::get()’
   66 |   template <typename OpT> static const OpDescription &get();
      |                                                       ^~~
make[2]: *** [CMakeFiles/llvm_dialects.dir/build.make:118: CMakeFiles/llvm_dialects.dir/lib/Dialect/OpDescription.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:259: CMakeFiles/llvm_dialects.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```
