### PR TITLE
Fix MSVC build.

### DIFF
--- a/lib/Dialect/OpDescription.cpp
+++ b/lib/Dialect/OpDescription.cpp
@@ -152,20 +152,23 @@ HANDLE_INTRINSIC_DESC_OPCODE_SET(LifetimeIntrinsic, Intrinsic::lifetime_start,
 #endif
 
 // Add Intrinsic::dbg_addr back for sufficiently recent LLVM
-HANDLE_INTRINSIC_DESC_OPCODE_SET(DbgInfoIntrinsic, Intrinsic::dbg_declare,
-                                 Intrinsic::dbg_value, Intrinsic::dbg_label
 #if HAVE_LLVM_VERSION_MAJOR >= 16
-                                 ,Intrinsic::dbg_assign
+HANDLE_INTRINSIC_DESC_OPCODE_SET(DbgInfoIntrinsic, Intrinsic::dbg_declare,
+                                 Intrinsic::dbg_value, Intrinsic::dbg_label,
+                                 Intrinsic::dbg_assign)
+#else
+HANDLE_INTRINSIC_DESC_OPCODE_SET(DbgInfoIntrinsic, Intrinsic::dbg_declare,
+                                 Intrinsic::dbg_value, Intrinsic::dbg_label)
 #endif
-                                 )
 
 // Add Intrinsic::dbg_addr back for sufficiently recent LLVM
-HANDLE_INTRINSIC_DESC_OPCODE_SET(DbgVariableIntrinsic, Intrinsic::dbg_declare,
-                                 Intrinsic::dbg_value
 #if HAVE_LLVM_VERSION_MAJOR >= 16
-                                 ,Intrinsic::dbg_assign
+HANDLE_INTRINSIC_DESC_OPCODE_SET(DbgVariableIntrinsic, Intrinsic::dbg_declare,
+                                 Intrinsic::dbg_value, Intrinsic::dbg_assign)
+#else
+HANDLE_INTRINSIC_DESC_OPCODE_SET(DbgVariableIntrinsic, Intrinsic::dbg_declare,
+                                 Intrinsic::dbg_value)
 #endif
-                                )
 
 HANDLE_INTRINSIC_DESC(DbgDeclareInst, dbg_declare)
 HANDLE_INTRINSIC_DESC(DbgValueInst, dbg_value)


### PR DESCRIPTION
The recent changes to OpDescription to handle different LLVM versions cause a UB warning on MSVC (which causes issues when trying to build on my MSVC 2022-based system, since the nested macro-evaluation order is slightly off):

C5101: use of preprocessor directive in function-like macro argument list is undefined behavior

I will start working on a MSVC-based CI build soon.