### PR TITLE
Remove support for multi-op OpDescriptions.

### DIFF
--- a/example/ExampleMain.cpp
+++ b/example/ExampleMain.cpp
@@ -32,6 +32,7 @@
 
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/Module.h"
@@ -145,7 +146,7 @@ struct VisitorNest {
   raw_ostream *out = nullptr;
   VisitorInnermost inner;
 
-  void visitBinaryOperator(BinaryOperator &inst) {
+  void visitBinaryOperator(Instruction &inst) {
     *out << "visiting BinaryOperator: " << inst << '\n';
   }
 };
@@ -204,11 +205,13 @@ template <bool rpot> const Visitor<VisitorContainer> &getExampleVisitor() {
                 }
               }
             });
-            b.add<UnaryInstruction>(
-                [](VisitorNest &self, UnaryInstruction &inst) {
-                  *self.out << "visiting UnaryInstruction: " << inst << '\n';
-                });
-            b.add(&VisitorNest::visitBinaryOperator);
+            b.addSet(OpSet::getClass<UnaryInstruction>(),
+                     [](VisitorNest &self, llvm::Instruction &inst) {
+                       *self.out << "visiting UnaryInstruction: " << inst
+                                 << '\n';
+                     });
+            b.addSet(OpSet::getClass<BinaryOperator>(),
+                     &VisitorNest::visitBinaryOperator);
             b.nest<raw_ostream>([](VisitorBuilder<raw_ostream> &b) {
               b.add<xd::WriteOp>([](raw_ostream &out, xd::WriteOp &op) {
                 out << "visiting WriteOp: " << op << '\n';

--- a/include/llvm-dialects/Dialect/OpDescription.h
+++ b/include/llvm-dialects/Dialect/OpDescription.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <variant>
@@ -44,7 +43,6 @@ public:
       : m_kind(hasOverloads ? Kind::DialectWithOverloads : Kind::Dialect),
         m_op(mnemonic) {}
   OpDescription(Kind kind, unsigned opcode) : m_kind(kind), m_op(opcode) {}
-  OpDescription(Kind kind, llvm::MutableArrayRef<unsigned> opcodes);
 
   static OpDescription fromCoreOp(unsigned op) { return {Kind::Core, op}; }
 
@@ -69,8 +67,6 @@ public:
 
   unsigned getOpcode() const;
 
-  llvm::ArrayRef<unsigned> getOpcodes() const;
-
   llvm::StringRef getMnemonic() const {
     assert(m_kind == Kind::Dialect || m_kind == Kind::DialectWithOverloads);
     return std::get<llvm::StringRef>(m_op);
@@ -92,9 +88,8 @@ private:
 
   // Holds one of:
   //  - core instruction opcode or intrinsic ID
-  //  - sorted array of opcodes or intrinsic IDs
   //  - mnemonic
-  std::variant<unsigned, llvm::ArrayRef<unsigned>, llvm::StringRef> m_op;
+  std::variant<unsigned, llvm::StringRef> m_op;
 };
 
 } // namespace llvm_dialects

--- a/include/llvm-dialects/Dialect/OpMap.h
+++ b/include/llvm-dialects/Dialect/OpMap.h
@@ -137,10 +137,6 @@ public:
   // Check if the map contains an op described by an OpDescription.
   bool contains(const OpDescription &desc) const {
     if (desc.isCoreOp() || desc.isIntrinsic()) {
-      assert(desc.getOpcodes().size() == 1 &&
-             "OpMap only supports querying of single core opcodes and "
-             "intrinsics.");
-
       const unsigned op = desc.getOpcode();
       return (desc.isCoreOp() && containsCoreOp(op)) ||
              (desc.isIntrinsic() && containsIntrinsic(op));
@@ -240,9 +236,6 @@ public:
       return {found, false};
 
     if (desc.isCoreOp() || desc.isIntrinsic()) {
-      assert(desc.getOpcodes().size() == 1 &&
-             "OpMap: Can only emplace a single op at a time.");
-
       const unsigned op = desc.getOpcode();
       if (desc.isCoreOp()) {
         auto [it, inserted] =
@@ -578,10 +571,6 @@ template <typename ValueT, bool isConst> class OpMapIteratorBase final {
   OpMapIteratorBase(OpMapT *map, const OpDescription &desc)
       : m_map{map}, m_desc{desc} {
     if (desc.isCoreOp() || desc.isIntrinsic()) {
-      assert(desc.getOpcodes().size() == 1 &&
-             "OpMapIterator only supports querying of single core opcodes and "
-             "intrinsics.");
-
       const unsigned op = desc.getOpcode();
 
       if (desc.isCoreOp()) {
@@ -659,10 +648,6 @@ public:
   template <bool Proxy = isConst, typename = std::enable_if_t<!Proxy>>
   bool erase() {
     if (m_desc.isCoreOp() || m_desc.isIntrinsic()) {
-      assert(m_desc.getOpcodes().size() == 1 &&
-             "OpMapIterator only supports erasing of single core opcodes and "
-             "intrinsics.");
-
       const unsigned op = m_desc.getOpcode();
 
       if (m_desc.isCoreOp())

--- a/include/llvm-dialects/Dialect/OpSet.h
+++ b/include/llvm-dialects/Dialect/OpSet.h
@@ -89,6 +89,8 @@ public:
     return set;
   }
 
+  template <typename ClassT> static const OpSet &getClass();
+
   // Construct an OpSet from a set of dialect ops, given as template
   // arguments.
   template <typename... OpTs> static const OpSet get() {
@@ -119,10 +121,6 @@ public:
   // Checks if a given OpDescription is stored in the set.
   bool contains(const OpDescription &desc) const {
     if (desc.isCoreOp() || desc.isIntrinsic()) {
-      assert(desc.getOpcodes().size() == 1 &&
-             "OpSet only supports querying of single core opcodes and "
-             "intrinsics.");
-
       const unsigned op = desc.getOpcode();
       return (desc.isCoreOp() && containsCoreOp(op)) ||
              (desc.isIntrinsic() && containsIntrinsicID(op));
@@ -189,15 +187,13 @@ private:
   // Tries to insert a given description in the internal data structures.
   void tryInsertOp(const OpDescription &desc) {
     if (desc.isCoreOp()) {
-      for (const unsigned op : desc.getOpcodes())
-        m_coreOpcodes.insert(op);
+      m_coreOpcodes.insert(desc.getOpcode());
 
       return;
     }
 
     if (desc.isIntrinsic()) {
-      for (const unsigned op : desc.getOpcodes())
-        m_intrinsicIDs.insert(op);
+      m_intrinsicIDs.insert(desc.getOpcode());
 
       return;
     }

--- a/lib/Dialect/Visitor.cpp
+++ b/lib/Dialect/Visitor.cpp
@@ -63,11 +63,11 @@ void VisitorTemplate::add(VisitorKey key, VisitorCallback *fn,
     const OpDescription *opDesc = key.m_description;
 
     if (opDesc->isCoreOp()) {
-      for (const unsigned op : opDesc->getOpcodes())
-        m_opMap[OpDescription::fromCoreOp(op)].push_back(handlerIdx);
+      m_opMap[OpDescription::fromCoreOp(opDesc->getOpcode())].push_back(
+          handlerIdx);
     } else if (opDesc->isIntrinsic()) {
-      for (const unsigned op : opDesc->getOpcodes())
-        m_opMap[OpDescription::fromIntrinsic(op)].push_back(handlerIdx);
+      m_opMap[OpDescription::fromIntrinsic(opDesc->getOpcode())].push_back(
+          handlerIdx);
     } else {
       m_opMap[*opDesc].push_back(handlerIdx);
     }


### PR DESCRIPTION
OpSet and OpMap only support querying of single-opcode OpDescriptions. This change modifies OpDescription to only allow storing a single operation, while OpSet becomes the first-class citizen for storing operand sets.
This change also adds some missing Visitor implementations to make working with the Visitor and the OpSet more pleasant.