### PR TITLE
Add support for typed pointers with the builtin PointerType.

### DIFF
--- a/include/llvm-dialects/Dialect/Dialect.td
+++ b/include/llvm-dialects/Dialect/Dialect.td
@@ -169,7 +169,8 @@ def I64 : TgConstant<(IntegerType 64)>, Type;
 
 def PointerType : BuiltinType {
   let arguments = (args type:$self, AttrI32:$address_space);
-  let evaluate = "::llvm::PointerType::get($_context, $address_space)";
+  // Supports both typed and opaque pointers.
+  let evaluate = "::llvm::PointerType::get(::llvm::Type::getInt8Ty($_context), $address_space)";
   let check = "$self->isPointerTy()";
   let capture = ["$self->getPointerAddressSpace()"];
 }

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -1478,9 +1478,9 @@ initial
 ::llvm::Type * const resultType = getResult()->getType();
 (void)resultType;
 
-        if (::llvm::PointerType::get(context, 0) != ptrType) {
+        if (::llvm::PointerType::get(::llvm::Type::getInt8Ty(context), 0) != ptrType) {
           errs << "  unexpected value of $ptr:\n";
-          errs << "    expected:  " << printable(::llvm::PointerType::get(context, 0)) << '\n';
+          errs << "    expected:  " << printable(::llvm::PointerType::get(::llvm::Type::getInt8Ty(context), 0)) << '\n';
           errs << "    actual:    " << printable(ptrType) << '\n';
         
           return false;
@@ -1570,9 +1570,9 @@ initial
 ::llvm::Type * const resultType = getResult()->getType();
 (void)resultType;
 
-        if (::llvm::PointerType::get(context, 0) != ptrType) {
+        if (::llvm::PointerType::get(::llvm::Type::getInt8Ty(context), 0) != ptrType) {
           errs << "  unexpected value of $ptr:\n";
-          errs << "    expected:  " << printable(::llvm::PointerType::get(context, 0)) << '\n';
+          errs << "    expected:  " << printable(::llvm::PointerType::get(::llvm::Type::getInt8Ty(context), 0)) << '\n';
           errs << "    actual:    " << printable(ptrType) << '\n';
         
           return false;
@@ -1662,9 +1662,9 @@ initial
 ::llvm::Type * const resultType = getResult()->getType();
 (void)resultType;
 
-        if (::llvm::PointerType::get(context, 0) != ptrType) {
+        if (::llvm::PointerType::get(::llvm::Type::getInt8Ty(context), 0) != ptrType) {
           errs << "  unexpected value of $ptr:\n";
-          errs << "    expected:  " << printable(::llvm::PointerType::get(context, 0)) << '\n';
+          errs << "    expected:  " << printable(::llvm::PointerType::get(::llvm::Type::getInt8Ty(context), 0)) << '\n';
           errs << "    actual:    " << printable(ptrType) << '\n';
         
           return false;


### PR DESCRIPTION
In some scenarios, we want to use typed pointers even if LLVM is moving to opaque pointers. Dialects currently only supports opaque pointers in its builtin. With this change, we simply return an i8* when evaluating a builtin pointer type return value or operand. This translates to an opaque pointer as well.
The client that creates the operations is responsible for handling the pointers correctly (e. g. not using opaque pointers in a
typed pointer scenario).