### PR TITLE
Replace deprecated starts/endswith

### DIFF
--- a/lib/Dialect/Dialect.cpp
+++ b/lib/Dialect/Dialect.cpp
@@ -279,7 +279,7 @@ bool llvm_dialects::detail::isOperationDecl(llvm::StringRef fn,
   if (isOverloaded) {
     if (mnemonic.size() >= fn.size())
       return false;
-    if (!fn.startswith(mnemonic))
+    if (!fn.starts_with(mnemonic))
       return false;
 
     return fn[mnemonic.size()] == '.';


### PR DESCRIPTION
`startswith` and `endswith` have been deprecated and are replaced with `starts_with` and `ends_with`.