### PR TITLE
Make Visitor more robust on instruction iteration

### DIFF
--- a/lib/Dialect/Visitor.cpp
+++ b/lib/Dialect/Visitor.cpp
@@ -269,8 +269,12 @@ void VisitorBase::visit(void *payload, Function &fn) const {
   if (m_strategy == VisitorStrategy::ReversePostOrder) {
     ReversePostOrderTraversal<Function *> rpot(&fn);
     for (BasicBlock *bb : rpot) {
-      for (Instruction &inst : make_early_inc_range(*bb))
-        visit(payload, inst);
+      // Allow callbacks to directly edit the code adding basic blocks
+      for (Instruction *inst = &*bb->begin(); inst != nullptr;) {
+        auto nextInst = inst->getNextNode();
+        visit(payload, *inst);
+        inst = nextInst;
+      }
     }
     return;
   }


### PR DESCRIPTION
Use a fixed end guard for the instruction iteration is not robust for callbacks to add a basic block. Use `Instruction::getNextNode()` for the iteration to allow callbacks to directly edit the code.