### PR TITLE
Add VisitorResult

### DIFF
--- a/test/example/visitor-basic.ll
+++ b/test/example/visitor-basic.ll
@@ -1,12 +1,15 @@
 ; RUN: llvm-dialects-example -visit %s | FileCheck --check-prefixes=DEFAULT %s
 
 ; DEFAULT: visiting ReadOp: %v = call i32 @xd.read.i32()
-; DEFAULT-NEXT: visiting UnaryInstruction: %w = load i32, ptr %p
-; DEFAULT-NEXT: visiting UnaryInstruction: %q = load i32, ptr %p1
+; DEFAULT-NEXT: visiting UnaryInstruction (pre): %w = load i32, ptr %p
+; DEFAULT-NEXT: visiting UnaryInstruction (pre): %q = load i32, ptr %p1
 ; DEFAULT-NEXT: visiting BinaryOperator: %v1 = add i32 %v, %w
 ; DEFAULT-NEXT: visiting umax intrinsic: %v2 = call i32 @llvm.umax.i32(i32 %v1, i32 %q)
 ; DEFAULT-NEXT: visiting WriteOp: call void (...) @xd.write(i8 %t)
+; DEFAULT-NEXT: visiting SetReadOp: %v.0 = call i1 @xd.set.read.i1()
+; DEFAULT-NEXT: visiting SetReadOp: %v.1 = call i32 @xd.set.read.i32()
 ; DEFAULT-NEXT: visiting SetReadOp (set): %v.1 = call i32 @xd.set.read.i32()
+; DEFAULT-NEXT: visiting UnaryInstruction (pre): %v.2 = trunc i32 %v.1 to i8
 ; DEFAULT-NEXT: visiting UnaryInstruction: %v.2 = trunc i32 %v.1 to i8
 ; DEFAULT-NEXT: visiting SetWriteOp (set): call void (...) @xd.set.write(i8 %v.2)
 ; DEFAULT-NEXT: visiting WriteVarArgOp: call void (...) @xd.write.vararg(i8 %t, i32 %v2, i32 %q)
@@ -27,6 +30,7 @@ entry:
   %v2 = call i32 @llvm.umax.i32(i32 %v1, i32 %q)
   %t = call i8 (...) @xd.itrunc.i8(i32 %v2)
   call void (...) @xd.write(i8 %t)
+  %v.0 = call i1 @xd.set.read.i1()
   %v.1 = call i32 @xd.set.read.i32()
   %v.2 = trunc i32 %v.1 to i8
   call void (...) @xd.set.write(i8 %v.2)
@@ -36,6 +40,7 @@ entry:
 }
 
 declare i32 @xd.read.i32()
+declare i1 @xd.set.read.i1()
 declare i32 @xd.set.read.i32()
 declare void @xd.write(...)
 declare void @xd.set.write(...)


### PR DESCRIPTION
Allow a visitor callback to decide whether additional matching callbacks for the same instruction should be called or not.

This is useful when a visitor callback wants to erase an instruction and there are multiple visitors that might match the same instruction (as sometimes happens with generic instructions like load and store).