### PR TITLE
Merge the lit and unit test suite.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ Common options are:
 Testing
 =======
 Run the `check-llvm-dialects` target to run a suite of automated tests.
+Run the `check-llvm-dialects-lit` target to run only the lit tests, and 
+the `check-llvm-dialects-units` to run only the unit tests.

--- a/docker/dialects.Dockerfile
+++ b/docker/dialects.Dockerfile
@@ -38,10 +38,7 @@ WORKDIR /vulkandriver/builds/ci-build
 RUN source /vulkandriver/env.sh \
     && cmake --build . --target llvm-dialects-tblgen
 
-# Run the lit test suite.
+# Run all test suites.
 RUN source /vulkandriver/env.sh \
     && cmake --build . --target check-llvm-dialects -- -v
 
-# Run the unit tests suite.
-RUN source /vulkandriver/env.sh \
-    && cmake --build . --target check-llvm-dialects-units -v

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,12 +40,12 @@ configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
 )
 
-add_lit_testsuite(check-llvm-dialects "Running the llvm-dialects regression tests"
+add_lit_testsuite(check-llvm-dialects-lit "Running the llvm-dialects regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   ${exclude_from_check_all}
   DEPENDS ${LLVM_DIALECTS_TEST_DEPENDS}
 )
-set_target_properties(check-llvm-dialects PROPERTIES FOLDER "Tests")
+set_target_properties(check-llvm-dialects-lit PROPERTIES FOLDER "Tests")
 
 add_lit_testsuites(LLVM_DIALECTS ${CMAKE_CURRENT_SOURCE_DIR}
   ${exclude_from_check_all}
@@ -53,3 +53,8 @@ add_lit_testsuites(LLVM_DIALECTS ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_subdirectory(unit)
+
+# Alias for all relevant tests
+add_custom_target(check-llvm-dialects
+  DEPENDS check-llvm-dialects-lit check-llvm-dialects-units
+)


### PR DESCRIPTION
Rename `check-llvm-dialects` => `check-llvm-dialects-lit` Add a new custom target `check-llvm-dialects` that runs both `check-llvm-dialects-lit` and `check-llvm-dialects-units`.

Run the combined test suite on CI.

While we only use the units test suite for `OpMap` and `OpSet` right now, it makes sense to have them executed both under a common name.