### PR TITLE
Remove trailing CR in test-generated.ll.

### DIFF
--- a/test/example/test-generated.test
+++ b/test/example/test-generated.test
@@ -1,2 +1,2 @@
-; RUN: diff -U 5 %S/generated/ExampleDialect.h.inc test_build_dir/../example/ExampleDialect.h.inc
-; RUN: diff -U 5 %S/generated/ExampleDialect.cpp.inc test_build_dir/../example/ExampleDialect.cpp.inc
+; RUN: diff --strip-trailing-cr -U 5 %S/generated/ExampleDialect.h.inc test_build_dir/../example/ExampleDialect.h.inc
+; RUN: diff --strip-trailing-cr -U 5 %S/generated/ExampleDialect.cpp.inc test_build_dir/../example/ExampleDialect.cpp.inc


### PR DESCRIPTION
Add the option `strip-trailing-cr` to avoid CR/LF-related test failures. The dialect files are created with LF, thus we don't want to see diff mismatches in git environments which check out with CRLF.