### PR TITLE
Error if duplicated mnemonics are found.

### DIFF
--- a/include/llvm-dialects/TableGen/Dialects.h
+++ b/include/llvm-dialects/TableGen/Dialects.h
@@ -21,6 +21,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/StringMap.h"
 
 namespace llvm {
 class DagInit;
@@ -47,10 +48,11 @@ public:
   std::string cppNamespace;
   std::vector<DialectType *> types;
   std::vector<OpClass *> opClasses;
+  llvm::StringMap<unsigned> operationCounts;
   std::vector<std::unique_ptr<Operation>> operations;
 
 public:
-  void finalize();
+  void finalize(llvm::raw_ostream &errs);
 
   llvm::ArrayRef<std::vector<Trait *>> attribute_lists() const {
     return m_attributeLists;

--- a/lib/TableGen/Operations.cpp
+++ b/lib/TableGen/Operations.cpp
@@ -447,6 +447,7 @@ bool Operation::parse(raw_ostream &errs, GenDialectsContext *context,
 
   op->m_builders.push_back(std::move(builder));
 
+  ++dialect->operationCounts[op->mnemonic];
   dialect->operations.push_back(std::move(op));
 
   return true;

--- a/test/tablegen/duplicate-ops.td
+++ b/test/tablegen/duplicate-ops.td
@@ -1,0 +1,45 @@
+// RUN: not --crash llvm-dialects-tblgen -gen-dialect-defs -dialect=dups -I%S/../../include %s 2>&1 | FileCheck --check-prefixes=CHECK %s
+
+// CHECK:      Found op with non-unique mnemonic: duplicate.op
+// CHECK-NEXT: Found op with non-unique mnemonic: duplicate.op.1
+// CHECK-NEXT: LLVM ERROR: Aborting dialect generation since non-unique mnemonics were found! 
+
+include "llvm-dialects/Dialect/Dialect.td"
+
+def TestDialect : Dialect {
+  let name = "dups";
+  let cppNamespace = "dups";
+}
+
+class TestOp<string mnemonic_, list<Trait> traits_>
+    : Op<TestDialect, mnemonic_, traits_>;
+
+def DuplicateOp : TestOp<"duplicate.op",
+                       []> {
+  let results = (outs);
+  let arguments = (ins);
+}
+
+def DuplicateOp1 : TestOp<"duplicate.op",
+                       []> {
+  let results = (outs);
+  let arguments = (ins);
+}
+
+def DuplicateOp2 : TestOp<"duplicate.op.1",
+                       []> {
+  let results = (outs);
+  let arguments = (ins);
+}
+
+def DuplicateOp3 : TestOp<"duplicate.op.1",
+                       []> {
+  let results = (outs);
+  let arguments = (ins);
+}
+
+def UniqueOp : TestOp<"unique.op",
+                       []> {
+  let results = (outs);
+  let arguments = (ins);
+}


### PR DESCRIPTION
We currently don't emit an error when a dialect defines two dialect operations with the same mnemonic. This change emits basic information about duplicate mnemonics.

Since this requires a `O(n)` loop worst-case, store the mnemonic counts per dialect in a `StringMap` and iterate over it during finalization of the dialect, which then also bails out.

Can possibly be extended to all kinds of duplicated symbols.