### PR TITLE
Fix argument count check for ops with only a variadic argument list.

### DIFF
--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -363,7 +363,7 @@ rhs,
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 3) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 3\n";
@@ -482,7 +482,7 @@ rhs
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 2) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 2\n";
@@ -577,7 +577,7 @@ index
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 2) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 2\n";
@@ -680,7 +680,7 @@ source
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 1) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 1\n";
@@ -844,7 +844,7 @@ source
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 0) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 0\n";
@@ -912,7 +912,7 @@ source
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 1) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 1\n";
@@ -1010,7 +1010,7 @@ source
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 1) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 1\n";
@@ -1110,7 +1110,7 @@ index
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 3) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 3\n";
@@ -1228,7 +1228,7 @@ instName_0
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 2) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 2\n";
@@ -1311,7 +1311,7 @@ instName
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 1) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 1\n";
@@ -1387,12 +1387,6 @@ instName
       (void)context;
 
       using ::llvm_dialects::printable;
-
-      if (arg_size() < 0) {
-        errs << "  wrong number of arguments: " << arg_size()
-               << ", expected at least 0\n";
-        return false;
-      }
   ::llvm::Type * const resultType = getResult()->getType();
 (void)resultType;
 
@@ -1457,7 +1451,7 @@ instName
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 0) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 0\n";
@@ -1514,7 +1508,7 @@ instName
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 0) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 0\n";
@@ -1571,7 +1565,7 @@ data
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 1) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 1\n";
@@ -1634,7 +1628,7 @@ data
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 1) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 1\n";
@@ -1713,7 +1707,7 @@ initial
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 3) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 3\n";
@@ -1805,7 +1799,7 @@ initial
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 3) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 3\n";
@@ -1897,7 +1891,7 @@ initial
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 3) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 3\n";
@@ -1984,7 +1978,7 @@ data
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() != 1) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected 1\n";
@@ -2049,7 +2043,7 @@ data
       (void)context;
 
       using ::llvm_dialects::printable;
-
+  
       if (arg_size() < 1) {
         errs << "  wrong number of arguments: " << arg_size()
                << ", expected at least 1\n";


### PR DESCRIPTION
We don't count variadic arguments in the `getNumFullArguments()` method since they can be zero. Not properly checking the return value of this function can however lead to a `arg_size() < 0` check in the generated verifier method. This happens if we only have a single variadic argument list argument.

This could also be solved with a call to `std::max` but just let us not emit verifier code instead.