### PR TITLE
Improve lit testing scripts.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 ##
  #######################################################################################################################
  #
- #  Copyright (c) 2020-2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ #  Copyright (c) 2020-2024 Advanced Micro Devices, Inc. All Rights Reserved.
  #
  #  Permission is hereby granted, free of charge, to any person obtaining a copy
  #  of this software and associated documentation files (the "Software"), to deal
@@ -42,10 +42,9 @@ configure_lit_site_cfg(
 
 add_lit_testsuite(check-llvm-dialects-lit "Running the llvm-dialects regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${exclude_from_check_all}
-  DEPENDS ${LLVM_DIALECTS_TEST_DEPENDS}
+  ${EXCLUDE_FROM_CHECK_ALL}
+  DEPENDS llvm-dialects-test-depends
 )
-set_target_properties(check-llvm-dialects-lit PROPERTIES FOLDER "Tests")
 
 add_lit_testsuites(LLVM_DIALECTS ${CMAKE_CURRENT_SOURCE_DIR}
   ${exclude_from_check_all}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -7,7 +7,8 @@ llvm_map_components_to_libnames(llvm_libs Support Core)
 set(DIALECTS_UNIT_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(DIALECTS_UNIT_TEST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
-function(add_dialects_unit_test test_folder)
+# Define test suite, link each test suite to llvm_dialects
+macro(add_dialects_unit_test test_folder)
     add_unittest(DialectsUnitTests ${test_folder} ${ARGN})
     target_link_libraries(${test_folder} PRIVATE ${llvm_libs} llvm_dialects)
 
@@ -20,10 +21,9 @@ function(add_dialects_unit_test test_folder)
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/../dialect
         ${CMAKE_CURRENT_BINARY_DIR}/../dialect)
-endfunction()
+endmacro()
 
 add_subdirectory(dialect)
-add_subdirectory(interface)
 
 # Let lit discover the GTest tests
 configure_lit_site_cfg(
@@ -33,7 +33,12 @@ configure_lit_site_cfg(
     ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
 )
 
+# Define the actual testing target. The tests are added in interface/.
 add_lit_testsuite(check-llvm-dialects-units "Running the llvm-dialects unit tests"
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${EXCLUDE_FROM_CHECK_ALL}
         DEPENDS TestDialectTableGen DialectsUnitTests)
+
+add_subdirectory(interface)
+
+set_target_properties(check-llvm-dialects-units PROPERTIES FOLDER "Tests")


### PR DESCRIPTION
- Let `check-llvm-dialects-lit` depend on the `llvm-dialects-test-depends` custom target
- Convert `add_dialects_unit_test` to a macro