### PR TITLE
Add `Dialect::isDialectOp` helper function.

### DIFF
--- a/example/ExampleMain.cpp
+++ b/example/ExampleMain.cpp
@@ -117,6 +117,8 @@ void createFunctionExample(Module &module, const Twine &name) {
   p2->setName("p2");
   b.create<xd::WriteOp>(p2);
 
+  assert(xd::ExampleDialect::isDialectOp(*cast<CallInst>(p2)));
+
   SmallVector<Value *> varArgs;
   varArgs.push_back(p1);
   varArgs.push_back(p2);

--- a/lib/TableGen/GenDialect.cpp
+++ b/lib/TableGen/GenDialect.cpp
@@ -107,6 +107,9 @@ class Builder;
 
     public:
       static Key& getKey();
+      static bool isDialectOp(::llvm::CallInst& op);
+      static bool isDialectOp(::llvm::Function& func);
+      static bool isDialectOp(::llvm::StringRef funcName);
 
     private:
       $Dialect(::llvm::LLVMContext& context);
@@ -296,6 +299,18 @@ void llvm_dialects::genDialectDefs(raw_ostream& out, RecordKeeper& records) {
     ::llvm_dialects::Dialect::Key& $Dialect::getKey() {
       static Key s_key;
       return s_key;
+    }
+
+    bool $Dialect::isDialectOp(::llvm::CallInst& op) {
+      return isDialectOp(op.getCalledFunction()->getName());
+    }
+
+    bool $Dialect::isDialectOp(::llvm::Function& func) {
+      return isDialectOp(func.getName());
+    }
+
+    bool $Dialect::isDialectOp(::llvm::StringRef funcName) {
+      return funcName.starts_with("$namespace.");
     }
 
     ::llvm_dialects::Dialect* $Dialect::make(::llvm::LLVMContext& context) {

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -30,6 +30,18 @@ namespace xd {
       return s_key;
     }
 
+    bool ExampleDialect::isDialectOp(::llvm::CallInst& op) {
+      return isDialectOp(op.getCalledFunction()->getName());
+    }
+
+    bool ExampleDialect::isDialectOp(::llvm::Function& func) {
+      return isDialectOp(func.getName());
+    }
+
+    bool ExampleDialect::isDialectOp(::llvm::StringRef funcName) {
+      return funcName.starts_with("xd.");
+    }
+
     ::llvm_dialects::Dialect* ExampleDialect::make(::llvm::LLVMContext& context) {
       
       auto verifierBuild = [](::llvm_dialects::VisitorBuilder<::llvm_dialects::VerifierState> &builder) {

--- a/test/example/generated/ExampleDialect.h.inc
+++ b/test/example/generated/ExampleDialect.h.inc
@@ -32,6 +32,9 @@ namespace xd {
 
     public:
       static Key& getKey();
+      static bool isDialectOp(::llvm::CallInst& op);
+      static bool isDialectOp(::llvm::Function& func);
+      static bool isDialectOp(::llvm::StringRef funcName);
 
     private:
       ExampleDialect(::llvm::LLVMContext& context);


### PR DESCRIPTION
We sometimes want to check if a given call instruction is prefixed with the cpp namespace assigned to the dialect. Instead of doing that manually, add a static dialect function that does this check.