### PR TITLE
Add additional nullptr check for `isDialectOp`

### DIFF
--- a/lib/TableGen/GenDialect.cpp
+++ b/lib/TableGen/GenDialect.cpp
@@ -302,7 +302,11 @@ void llvm_dialects::genDialectDefs(raw_ostream& out, RecordKeeper& records) {
     }
 
     bool $Dialect::isDialectOp(::llvm::CallInst& op) {
-      return isDialectOp(op.getCalledFunction()->getName());
+      ::llvm::Function *calledFunc = op.getCalledFunction(); 
+      if (!calledFunc)
+        return false;
+      
+      return isDialectOp(calledFunc->getName());
     }
 
     bool $Dialect::isDialectOp(::llvm::Function& func) {

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -31,7 +31,11 @@ namespace xd {
     }
 
     bool ExampleDialect::isDialectOp(::llvm::CallInst& op) {
-      return isDialectOp(op.getCalledFunction()->getName());
+      ::llvm::Function *calledFunc = op.getCalledFunction(); 
+      if (!calledFunc)
+        return false;
+      
+      return isDialectOp(calledFunc->getName());
     }
 
     bool ExampleDialect::isDialectOp(::llvm::Function& func) {


### PR DESCRIPTION
`getCalledFunction()` can return `nullptr`.