### PR TITLE
Add ImmutableString  default name of a global variable

### DIFF
--- a/include/llvm-dialects/Dialect/Dialect.td
+++ b/include/llvm-dialects/Dialect/Dialect.td
@@ -280,7 +280,7 @@ def : AttrLlvmType<AttrI32, I32>;
 def : AttrLlvmType<AttrI64, I64>;
 
 def ImmutableStringAttr : Attr<"::llvm::StringRef"> {
-  let toLlvmValue = [{ $_builder.CreateGlobalString($0) }];
+  let toLlvmValue = [{ $_builder.CreateGlobalString($0, "str") }];
   let fromLlvmValue = [{ ::llvm::cast<::llvm::ConstantDataArray>(::llvm::cast<::llvm::GlobalVariable>($0)->getInitializer())->getAsString() }];
   let isImmutable = true;
 }

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -2064,7 +2064,7 @@ initial
 
   
 ::llvm::SmallVector<::llvm::Value*, 1> args = {
- b.CreateGlobalString(val) 
+ b.CreateGlobalString(val, "str") 
       };
       
       return ::llvm::cast<StringAttrOp>(b.CreateCall(fn, args, instName));

--- a/test/example/test-builder.test
+++ b/test/example/test-builder.test
@@ -3,7 +3,7 @@
 ; RUN: llvm-dialects-example - | FileCheck --check-prefixes=CHECK %s
 
 ;.
-; CHECK: @[[GLOB0:[0-9]+]] = private unnamed_addr constant [13 x i8] c"Hello world!\00", align 1
+; CHECK: @[[GLOB0:.*]] = private unnamed_addr constant [13 x i8] c"Hello world!\00", align 1
 ;.
 ; CHECK-LABEL: @example(
 ; CHECK-NEXT:  entry:
@@ -45,6 +45,6 @@
 ; CHECK-NEXT:    [[TWO_VARARGS:%.*]] = call i32 (...) @xd.inst.name.conflict.varargs(ptr [[P1]], i8 [[P2]])
 ; CHECK-NEXT:    [[THREE_VARARGS:%.*]] = call i32 (...) @xd.inst.name.conflict.varargs(ptr [[P1]], i8 [[P2]], i32 3)
 ; CHECK-NEXT:    [[FOUR_VARARGS:%.*]] = call i32 (...) @xd.inst.name.conflict.varargs(ptr [[P1]], i8 [[P2]], i32 3, i32 4)
-; CHECK-NEXT:    call void @xd.string.attr.op(ptr @[[GLOB0:[0-9]+]])
+; CHECK-NEXT:    call void @xd.string.attr.op(ptr @[[GLOB0]])
 ; CHECK-NEXT:    ret void
 ;


### PR DESCRIPTION
Add name to the global variable as the name is required for the crossliner to include as global variable