### PR TITLE
Delete MMX name mangler case

### DIFF
--- a/lib/Dialect/Utils.cpp
+++ b/lib/Dialect/Utils.cpp
@@ -11,7 +11,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License. 
+ * limitations under the License.
  */
 
 #include "llvm-dialects/Dialect/Utils.h"
@@ -116,7 +116,6 @@ static std::string getMangledTypeStr(Type *Ty, bool &HasUnnamedType) {
     case Type::X86_FP80TyID:  Result += "f80";      break;
     case Type::FP128TyID:     Result += "f128";     break;
     case Type::PPC_FP128TyID: Result += "ppcf128";  break;
-    case Type::X86_MMXTyID:   Result += "x86mmx";   break;
     case Type::X86_AMXTyID:   Result += "x86amx";   break;
     case Type::IntegerTyID:
       Result += "i" + utostr(cast<IntegerType>(Ty)->getBitWidth());


### PR DESCRIPTION
The type was removed in https://github.com/llvm/llvm-project/pull/98505