### PR TITLE
Fix picking ByDeclaration strategy

### DIFF
--- a/include/llvm-dialects/Dialect/OpMap.h
+++ b/include/llvm-dialects/Dialect/OpMap.h
@@ -339,6 +339,10 @@ public:
            m_dialectOps.empty();
   }
 
+  bool emptyCoreOpcodes() const {
+    return m_coreOpcodes.empty();
+  }
+
   // --------------------------------------------------------------------------
   // Iterator definitions.
   // --------------------------------------------------------------------------

--- a/lib/Dialect/Visitor.cpp
+++ b/lib/Dialect/Visitor.cpp
@@ -185,8 +185,8 @@ VisitorBase::VisitorBase(VisitorTemplate &&templ)
     : m_strategy(templ.m_strategy),
       m_projections(std::move(templ.m_projections)) {
   if (m_strategy == VisitorStrategy::Default) {
-    m_strategy = templ.m_opMap.empty() ? VisitorStrategy::ByFunctionDeclaration
-                                       : VisitorStrategy::ByInstruction;
+    m_strategy = templ.m_opMap.emptyCoreOpcodes() ? VisitorStrategy::ByFunctionDeclaration
+                                                  : VisitorStrategy::ByInstruction;
   }
 
   BuildHelper helper(*this, templ.m_handlers);


### PR DESCRIPTION
Due to refactorings, the ByInstruction strategy was always picked. Fix that and only pick ByInstruction if there are opcodes that need it.