### PR TITLE
Reflect upstream const changes

### DIFF
--- a/include/llvm-dialects/TableGen/Common.h
+++ b/include/llvm-dialects/TableGen/Common.h
@@ -17,6 +17,15 @@
 #pragma once
 
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/TableGen/Record.h"
+
+#if !defined(LLVM_MAIN_REVISION) || LLVM_MAIN_REVISION >= 513628
+using RecordKeeperTy = const llvm::RecordKeeper;
+using RecordTy = const llvm::Record;
+#else
+using RecordKeeperTy = llvm::RecordKeeper;
+using RecordTy = llvm::Record;
+#endif
 
 namespace llvm_dialects {
 

--- a/include/llvm-dialects/TableGen/Constraints.h
+++ b/include/llvm-dialects/TableGen/Constraints.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "llvm-dialects/TableGen/Common.h"
 #include "llvm-dialects/TableGen/NamedValue.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -220,9 +221,8 @@ public:
     return type->getKind() == Kind::Attr;
   }
 
-  static std::unique_ptr<Attr> parse(llvm::raw_ostream &errs,
-                                     GenDialectsContext &context,
-                                     llvm::Record *record);
+  static std::unique_ptr<Attr>
+  parse(llvm::raw_ostream &errs, GenDialectsContext &context, RecordTy *record);
 
   llvm::StringRef getName() const;
   llvm::StringRef getCppType() const { return m_cppType; }
@@ -243,7 +243,7 @@ public:
   }
 
 private:
-  llvm::Record *m_record = nullptr;
+  RecordTy *m_record = nullptr;
   std::string m_cppType;
   llvm::Init *m_llvmType = nullptr;
   std::string m_toLlvmValue;

--- a/include/llvm-dialects/TableGen/DialectType.h
+++ b/include/llvm-dialects/TableGen/DialectType.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "llvm-dialects/TableGen/Common.h"
 #include "llvm-dialects/TableGen/Predicates.h"
 
 #include "llvm-dialects/TableGen/SymbolTable.h"
@@ -40,7 +41,7 @@ public:
     return arguments().drop_front(1);
   }
 
-  llvm::Record *getDialectRec() const { return m_dialectRec; }
+  RecordTy *getDialectRec() const { return m_dialectRec; }
   llvm::StringRef getName() const { return m_name; }
   llvm::StringRef getMnemonic() const { return m_mnemonic; }
   bool defaultGetterHasExplicitContextArgument() const {
@@ -58,7 +59,7 @@ private:
     std::string name;
   };
 
-  llvm::Record *m_dialectRec = nullptr;
+  RecordTy *m_dialectRec = nullptr;
   std::string m_name;
   std::string m_mnemonic;
   bool m_defaultGetterHasExplicitContextArgument = false;

--- a/include/llvm-dialects/TableGen/Dialects.h
+++ b/include/llvm-dialects/TableGen/Dialects.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "llvm-dialects/TableGen/Common.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
@@ -42,7 +43,7 @@ class Trait;
 
 class GenDialect {
 public:
-  llvm::Record *record;
+  RecordTy *record;
   std::string cppName;
   std::string name;
   std::string cppNamespace;
@@ -69,14 +70,14 @@ public:
   GenDialectsContext();
   ~GenDialectsContext();
 
-  void init(llvm::RecordKeeper &records,
+  void init(RecordKeeperTy &records,
             const llvm::DenseSet<llvm::StringRef> &dialects);
 
-  Trait *getTrait(llvm::Record *traitRec);
+  Trait *getTrait(RecordTy *traitRec);
   Predicate *getPredicate(llvm::Init *init, llvm::raw_ostream &errs);
-  Attr *getAttr(llvm::Record *record, llvm::raw_ostream &errs);
-  OpClass *getOpClass(llvm::Record *opClassRec);
-  GenDialect *getDialect(llvm::Record *dialectRec);
+  Attr *getAttr(RecordTy *record, llvm::raw_ostream &errs);
+  OpClass *getOpClass(RecordTy *opClassRec);
+  GenDialect *getDialect(RecordTy *dialectRec);
 
   llvm::Init *getVoidTy() const { return m_voidTy; }
   llvm::Init *getAny() const { return m_any; }
@@ -92,11 +93,11 @@ private:
   llvm::Init *m_voidTy = nullptr;
   llvm::Init *m_any = nullptr;
   bool m_attrsComplete = false;
-  llvm::DenseMap<llvm::Record *, std::unique_ptr<Trait>> m_traits;
+  llvm::DenseMap<RecordTy *, std::unique_ptr<Trait>> m_traits;
   llvm::DenseMap<llvm::Init *, std::unique_ptr<Predicate>> m_predicates;
-  llvm::DenseMap<llvm::Record *, std::unique_ptr<Attr>> m_attrs;
-  llvm::DenseMap<llvm::Record *, std::unique_ptr<OpClass>> m_opClasses;
-  llvm::DenseMap<llvm::Record *, std::unique_ptr<GenDialect>> m_dialects;
+  llvm::DenseMap<RecordTy *, std::unique_ptr<Attr>> m_attrs;
+  llvm::DenseMap<RecordTy *, std::unique_ptr<OpClass>> m_opClasses;
+  llvm::DenseMap<RecordTy *, std::unique_ptr<GenDialect>> m_dialects;
 };
 
 } // namespace llvm_dialects

--- a/include/llvm-dialects/TableGen/GenDialect.h
+++ b/include/llvm-dialects/TableGen/GenDialect.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "llvm-dialects/TableGen/Common.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
@@ -24,7 +25,7 @@ class RecordKeeper;
 
 namespace llvm_dialects {
 
-void genDialectDecls(llvm::raw_ostream& out, llvm::RecordKeeper& records);
-void genDialectDefs(llvm::raw_ostream& out, llvm::RecordKeeper& records);
+void genDialectDecls(llvm::raw_ostream &out, RecordKeeperTy &records);
+void genDialectDefs(llvm::raw_ostream &out, RecordKeeperTy &records);
 
 } // namespace llvm_dialects

--- a/include/llvm-dialects/TableGen/Operations.h
+++ b/include/llvm-dialects/TableGen/Operations.h
@@ -67,7 +67,7 @@ public:
 
 protected:
   bool init(llvm::raw_ostream &errs, GenDialectsContext &context,
-            llvm::Record *record);
+            RecordTy *record);
 
   /// Records if this Operation has a variadic argument
   bool m_hasVariadicArgument = false;
@@ -91,9 +91,8 @@ public:
   std::vector<OpClass *> subclasses;
   std::vector<Operation *> operations;
 
-  static std::unique_ptr<OpClass> parse(llvm::raw_ostream &errs,
-                                        GenDialectsContext &context,
-                                        llvm::Record *record);
+  static std::unique_ptr<OpClass>
+  parse(llvm::raw_ostream &errs, GenDialectsContext &context, RecordTy *record);
 };
 
 class Operation : public OperationBase {
@@ -110,7 +109,7 @@ public:
   ~Operation();
 
   static bool parse(llvm::raw_ostream &errs, GenDialectsContext *context,
-                    GenDialect *dialect, llvm::Record *record);
+                    GenDialect *dialect, RecordTy *record);
 
   bool haveResultOverloads() const { return m_haveResultOverloads; }
   bool haveArgumentOverloads() const { return m_haveArgumentOverloads; }

--- a/include/llvm-dialects/TableGen/Traits.h
+++ b/include/llvm-dialects/TableGen/Traits.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 
+#include "llvm-dialects/TableGen/Common.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace llvm {
@@ -42,14 +43,14 @@ public:
   };
 
   static std::unique_ptr<Trait> fromRecord(GenDialectsContext *context,
-                                           llvm::Record *record);
+                                           RecordTy *record);
 
   virtual ~Trait() = default;
 
-  virtual void init(GenDialectsContext *context, llvm::Record *record);
+  virtual void init(GenDialectsContext *context, RecordTy *record);
 
   Kind getKind() const { return m_kind; }
-  llvm::Record *getRecord() const { return m_record; }
+  RecordTy *getRecord() const { return m_record; }
   llvm::StringRef getName() const;
 
 protected:
@@ -57,7 +58,7 @@ protected:
 
 private:
   const Kind m_kind;
-  llvm::Record *m_record = nullptr;
+  RecordTy *m_record = nullptr;
 };
 
 class LlvmAttributeTrait : public Trait {

--- a/lib/TableGen/Constraints.cpp
+++ b/lib/TableGen/Constraints.cpp
@@ -93,7 +93,7 @@ bool ConstraintSystem::addConstraint(raw_ostream &errs, Init *init,
 bool ConstraintSystem::addConstraintImpl(raw_ostream &errs, Init *init,
                                          Variable *self) {
   if (auto *dag = dyn_cast<DagInit>(init)) {
-    Record *op = dag->getOperatorAsDef({});
+    RecordTy *op = dag->getOperatorAsDef({});
 
     auto isValidOperand = [&dag, &errs](size_t index,
                                         StringRef opName) -> bool {
@@ -385,8 +385,8 @@ StringRef MetaType::getName() const {
   return "value";
 }
 
-std::unique_ptr<Attr> Attr::parse(raw_ostream &errs,
-                                  GenDialectsContext &context, Record *record) {
+std::unique_ptr<Attr>
+Attr::parse(raw_ostream &errs, GenDialectsContext &context, RecordTy *record) {
   if (!record->isSubClassOf("Attr")) {
     errs << record->getName() << ": must be a subclass of Attr\n";
     return {};

--- a/lib/TableGen/DialectType.cpp
+++ b/lib/TableGen/DialectType.cpp
@@ -30,7 +30,7 @@ bool DialectType::init(raw_ostream &errs, GenDialectsContext &context,
   if (!BaseCppPredicate::init(errs, context, theInit))
     return false;
 
-  Record *record = cast<DefInit>(theInit)->getDef();
+  RecordTy *record = cast<DefInit>(theInit)->getDef();
 
   m_dialectRec = record->getValueAsDef("dialect");
   if (!m_dialectRec->isSubClassOf("Dialect")) {

--- a/lib/TableGen/GenDialect.cpp
+++ b/lib/TableGen/GenDialect.cpp
@@ -41,7 +41,7 @@ cl::opt<std::string> g_dialect("dialect", cl::desc("the dialect to generate"), c
 } // anonymous namespace
 
 static std::pair<std::unique_ptr<GenDialectsContext>, GenDialect *>
-getSelectedDialect(RecordKeeper &records) {
+getSelectedDialect(RecordKeeperTy &records) {
   if (g_dialect.empty())
     report_fatal_error(Twine("Must select a dialect using the --dialect option"));
 
@@ -51,7 +51,7 @@ getSelectedDialect(RecordKeeper &records) {
 
   context->init(records, dialects);
 
-  for (Record* dialectRec : records.getAllDerivedDefinitions("Dialect")) {
+  for (RecordTy *dialectRec : records.getAllDerivedDefinitions("Dialect")) {
     if (dialectRec->getValueAsString("name") == g_dialect) {
       GenDialect *selectedDialect = context->getDialect(dialectRec);
       return {std::move(context), selectedDialect};
@@ -61,7 +61,7 @@ getSelectedDialect(RecordKeeper &records) {
   report_fatal_error(Twine("Could not find dialect. Check the '--dialect' option."));
 }
 
-void llvm_dialects::genDialectDecls(raw_ostream& out, RecordKeeper& records) {
+void llvm_dialects::genDialectDecls(raw_ostream &out, RecordKeeperTy &records) {
   auto [context, dialect] = getSelectedDialect(records);
 
   emitHeader(out);
@@ -218,7 +218,7 @@ class Builder;
 )";
 }
 
-void llvm_dialects::genDialectDefs(raw_ostream& out, RecordKeeper& records) {
+void llvm_dialects::genDialectDefs(raw_ostream &out, RecordKeeperTy &records) {
   auto [contextPtr, dialect] = getSelectedDialect(records);
   auto &genDialectsContext = *contextPtr;
 

--- a/lib/TableGen/NamedValue.cpp
+++ b/lib/TableGen/NamedValue.cpp
@@ -57,7 +57,7 @@ NamedValue::parseList(raw_ostream &errs, GenDialectsContext &context,
     bool accepted = false;
 
     if (auto *defInit = dyn_cast<DefInit>(valueInit)) {
-      Record *def = defInit->getDef();
+      RecordTy *def = defInit->getDef();
 
       if (def->getName() == "type") {
         if (mode == Parser::OperationResults ||

--- a/lib/TableGen/Operations.cpp
+++ b/lib/TableGen/Operations.cpp
@@ -32,8 +32,8 @@ static std::string evaluateAttrLlvmType(raw_ostream &errs, raw_ostream &out,
                                         SymbolTable &symbols);
 
 static std::optional<std::vector<NamedValue>>
-parseArguments(raw_ostream &errs, GenDialectsContext &context, Record *rec) {
-  Record *superClassRec = rec->getValueAsDef("superclass");
+parseArguments(raw_ostream &errs, GenDialectsContext &context, RecordTy *rec) {
+  RecordTy *superClassRec = rec->getValueAsDef("superclass");
   OpClass *superclass = context.getOpClass(superClassRec);
   DagInit *argsInit = rec->getValueAsDag("arguments");
 
@@ -78,7 +78,7 @@ private:
 } // namespace
 
 bool OperationBase::init(raw_ostream &errs, GenDialectsContext &context,
-                         Record *record) {
+                         RecordTy *record) {
   m_dialect = context.getDialect(record->getValueAsDef("dialect"));
   m_superclass = context.getOpClass(record->getValueAsDef("superclass"));
 
@@ -280,8 +280,9 @@ void OperationBase::emitArgumentAccessorDefinitions(llvm::raw_ostream &out,
   }
 }
 
-std::unique_ptr<OpClass>
-OpClass::parse(raw_ostream &errs, GenDialectsContext &context, Record *record) {
+std::unique_ptr<OpClass> OpClass::parse(raw_ostream &errs,
+                                        GenDialectsContext &context,
+                                        RecordTy *record) {
   auto opClass = std::make_unique<OpClass>();
   opClass->name = record->getName();
 
@@ -329,7 +330,7 @@ Operation::Operation(GenDialectsContext &context) : m_system(context, m_scope) {
 Operation::~Operation() = default;
 
 bool Operation::parse(raw_ostream &errs, GenDialectsContext *context,
-                      GenDialect *dialect, Record *record) {
+                      GenDialect *dialect, RecordTy *record) {
   auto op = std::make_unique<Operation>(*context);
 
   if (!op->init(errs, *context, record))
@@ -342,7 +343,7 @@ bool Operation::parse(raw_ostream &errs, GenDialectsContext *context,
 
   op->name = record->getName();
   op->mnemonic = record->getValueAsString("mnemonic");
-  for (Record *traitRec : record->getValueAsListOfDefs("traits"))
+  for (RecordTy *traitRec : record->getValueAsListOfDefs("traits"))
     op->traits.push_back(context->getTrait(traitRec));
 
   EvaluationPlanner evaluation(op->m_system);

--- a/lib/TableGen/Predicates.cpp
+++ b/lib/TableGen/Predicates.cpp
@@ -34,7 +34,7 @@ std::unique_ptr<Predicate> Predicate::parse(raw_ostream &errs,
   if (isa<IntInit>(theInit)) {
     result = std::make_unique<Constant>();
   } else if (auto *defInit = dyn_cast<DefInit>(theInit)) {
-    Record *record = defInit->getDef();
+    RecordTy *record = defInit->getDef();
     if (!record->isSubClassOf("Predicate")) {
       errs << record->getName()
            << ": trying to use as predicate, but not a subclass of Predicate\n";
@@ -73,10 +73,10 @@ bool Predicate::init(raw_ostream &errs, GenDialectsContext &genContext,
   m_init = theInit;
 
   if (auto *defInit = dyn_cast<DefInit>(theInit)) {
-    Record *record = defInit->getDef();
+    RecordTy *record = defInit->getDef();
 
     auto *arguments = record->getValueAsDag("arguments");
-    Record *argOp = arguments->getOperatorAsDef({});
+    RecordTy *argOp = arguments->getOperatorAsDef({});
     if (argOp->getName() != "args") {
       errs << "  argument list has unexpected operator: " << argOp->getName()
            << '\n';
@@ -108,7 +108,7 @@ bool TgPredicate::init(raw_ostream &errs, GenDialectsContext &genContext,
   if (!Predicate::init(errs, genContext, theInit))
     return false;
 
-  Record *record = cast<DefInit>(theInit)->getDef();
+  RecordTy *record = cast<DefInit>(theInit)->getDef();
 
   for (const auto &argument : arguments())
     m_variables.push_back(m_scope.getVariable(argument.name));
@@ -155,7 +155,7 @@ bool CppPredicate::init(raw_ostream &errs, GenDialectsContext &genContext,
   if (!BaseCppPredicate::init(errs, genContext, theInit))
     return false;
 
-  Record *record = cast<DefInit>(theInit)->getDef();
+  RecordTy *record = cast<DefInit>(theInit)->getDef();
 
   m_evaluate = record->getValueAsString("evaluate");
   m_canDerive.push_back(!m_evaluate.empty());

--- a/lib/TableGen/Traits.cpp
+++ b/lib/TableGen/Traits.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "llvm-dialects/TableGen/Traits.h"
+#include "llvm-dialects/TableGen/Common.h"
 
 #include "llvm-dialects/TableGen/Format.h"
 
@@ -35,7 +36,7 @@ class LlvmEnumAttributeTrait : public LlvmAttributeTrait {
 public:
   LlvmEnumAttributeTrait() : LlvmAttributeTrait(Kind::LlvmEnumAttributeTrait) {}
 
-  void init(GenDialectsContext *context, llvm::Record *record) override;
+  void init(GenDialectsContext *context, RecordTy *record) override;
 
   void addAttribute(llvm::raw_ostream &out, FmtContext &fmt) const override;
 
@@ -54,7 +55,7 @@ public:
   LlvmMemoryAttributeTrait()
       : LlvmAttributeTrait(Kind::LlvmMemoryAttributeTrait) {}
 
-  void init(GenDialectsContext *context, llvm::Record *record) override;
+  void init(GenDialectsContext *context, RecordTy *record) override;
 
   void addAttribute(llvm::raw_ostream &out, FmtContext &fmt) const override;
 
@@ -80,7 +81,7 @@ bool llvm_dialects::noMemoryEffects() {
 }
 
 std::unique_ptr<Trait> Trait::fromRecord(GenDialectsContext *context,
-                                         llvm::Record *traitRec) {
+                                         RecordTy *traitRec) {
   std::unique_ptr<Trait> result;
   if (traitRec->isSubClassOf("LlvmEnumAttributeTrait")) {
     result = std::make_unique<LlvmEnumAttributeTrait>();
@@ -93,13 +94,14 @@ std::unique_ptr<Trait> Trait::fromRecord(GenDialectsContext *context,
   return result;
 }
 
-void Trait::init(GenDialectsContext *context, Record *record) {
+void Trait::init(GenDialectsContext *context, RecordTy *record) {
   m_record = record;
 }
 
 StringRef Trait::getName() const { return m_record->getName(); }
 
-void LlvmEnumAttributeTrait::init(GenDialectsContext *context, Record *record) {
+void LlvmEnumAttributeTrait::init(GenDialectsContext *context,
+                                  RecordTy *record) {
   LlvmAttributeTrait::init(context, record);
   m_llvmEnum = record->getValueAsString("llvmEnum");
 }
@@ -111,14 +113,14 @@ void LlvmEnumAttributeTrait::addAttribute(raw_ostream &out,
 }
 
 void LlvmMemoryAttributeTrait::init(GenDialectsContext *context,
-                                    llvm::Record *record) {
+                                    RecordTy *record) {
   LlvmAttributeTrait::init(context, record);
 
   auto *effects = record->getValueAsListInit("effects");
   for (auto *effectInit : *effects) {
     Effect effect;
     auto *effectDag = cast<DagInit>(effectInit);
-    Record *op = effectDag->getOperatorAsDef(record->getLoc());
+    RecordTy *op = effectDag->getOperatorAsDef(record->getLoc());
     if (op->getName() == "read") {
       effect.read = true;
     } else if (op->getName() == "write") {

--- a/utils/llvm-dialects-tblgen.cpp
+++ b/utils/llvm-dialects-tblgen.cpp
@@ -14,6 +14,7 @@
  * limitations under the License. 
  */
 
+#include "llvm-dialects/TableGen/Common.h"
 #include "llvm-dialects/TableGen/GenDialect.h"
 
 #include "llvm/Support/CommandLine.h"
@@ -53,7 +54,7 @@ cl::opt<Action> g_action(
                    "Generate dialect definitions (.cpp.inc)")
         ));
 
-bool llvmDialectsTableGenMain(raw_ostream& out, RecordKeeper& records) {
+bool llvmDialectsTableGenMain(raw_ostream &out, RecordKeeperTy &records) {
   switch (g_action) {
   case Action::PrintRecords:
     // Redundant with llvm-tblgen, but may be convenient for users.


### PR DESCRIPTION
`TableGenFnMain` was changed to pass a `const RecordKeeper &`, so
reflect that change in `llvm-dialects`. Also, `const Record *` pointers
are handed out now.
Adds a bunch of changes to make `Record *` const overall.
Guard both versions with LLVM_MAIN_REVISION to ensure upstream and
downstream CI continues to work.