### PR TITLE
Silence a warning on gcc 13

### DIFF
--- a/lib/TableGen/Evaluator.cpp
+++ b/lib/TableGen/Evaluator.cpp
@@ -643,14 +643,13 @@ bool Evaluator::checkLogicOr(bool writeErrs, const LogicOr *logicOr) {
                      &m_fmt);
     }
 
-    for (unsigned i = 0; i < logicOr->branches().size(); ++i) {
+    for (auto [i, childSystem] : llvm::enumerate(logicOr->branches())) {
       m_out << tgfmt(R"(
         $_errs << "  failed option $0 ($1):\n";
         ([&]() {
       )",
                      &m_fmt, i, logicOr->branchInits()[i]->getAsString());
 
-      const ConstraintSystem &childSystem = logicOr->branches()[i];
       Assignment scopedAssignment{&m_assignment};
       Evaluator childEvaluator(*m_symbols, scopedAssignment, childSystem, m_out,
                                m_fmt);


### PR DESCRIPTION
GCC 13 produced a warning that:

.../llvm-dialects/lib/TableGen/Evaluator.cpp:653:31: warning: possibly dangling reference to a temporary [-Wdangling-reference]
  653 |       const ConstraintSystem &childSystem = logicOr->branches()[i];
      |                               ^~~~~~~~~~~
.../llvm-dialects/lib/TableGen/Evaluator.cpp:653:66: note: the temporary was destroyed at the end of the full expression ‘logicOr->llvm_dialects::LogicOr::branches().llvm::ArrayRef<llvm_dialects::ConstraintSystem>::operator[](((size_t)i))’
  653 |       const ConstraintSystem &childSystem = logicOr->branches()[i];
      |                                                                  ^

This warning seems wrong. The temporary ArrayRef returned by LogicOr::branches() is destroyed, yes, but the reference returned by operator[] isn't a reference into the ArrayRef itself, so it shouldn't matter.

Oh well. Using a for-each loop is nicer anyway.