### PR TITLE
Comma expresion for MSVC fold expression bug

### DIFF
--- a/include/llvm-dialects/Dialect/OpSet.h
+++ b/include/llvm-dialects/Dialect/OpSet.h
@@ -92,10 +92,7 @@ public:
   template <typename... OpTs> static const OpSet &get() {
     static const auto set = ([]() {
       OpSet set;
-      (void)(... && ([&set]() {
-               set.tryInsertOp(OpDescription::get<OpTs>());
-               return true;
-             })());
+      (..., set.tryInsertOp(OpDescription::get<OpTs>()));
       return set;
     })();
     return set;


### PR DESCRIPTION
Boolean fold expression seems like some bugs in MSVC, it's incorrectly
removed. In other projects, we found similar problems. But gcc or clang
not.

On the other hand, fold expression with comma seems cleaner than lambda.

Referenced-by: zigrazor/cxxgraph#415