### PR TITLE
Allow Visitor to use CallInst

### DIFF
--- a/example/ExampleMain.cpp
+++ b/example/ExampleMain.cpp
@@ -264,6 +264,12 @@ template <bool rpot> const Visitor<VisitorContainer> &getExampleVisitor() {
               b.add<ReturnInst>([](raw_ostream &out, ReturnInst &ret) {
                 out << "visiting ReturnInst: " << ret << '\n';
               });
+              b.add<CallInst>([](raw_ostream &out, CallInst &ret) {
+                out << "visiting CallInst: " << ret << '\n';
+              });
+              b.add<CallBrInst>([](raw_ostream &out, CallBrInst &ret) {
+                out << "visiting CallBrInst: " << ret << '\n';
+              });
               b.addIntrinsic(
                   Intrinsic::umax, [](raw_ostream &out, IntrinsicInst &umax) {
                     out << "visiting umax intrinsic: " << umax << '\n';

--- a/include/llvm-dialects/Dialect/OpMap.h
+++ b/include/llvm-dialects/Dialect/OpMap.h
@@ -605,15 +605,12 @@ template <typename ValueT, bool isConst> class OpMapIteratorBase final {
       invalidate();
   }
 
-  // Do a lookup for a given instruction. Mark the iterator as invalid
-  // if the instruction is a call-like core instruction.
+  // Do a lookup for a given instruction.
   OpMapIteratorBase(OpMapT *map, const llvm::Instruction &inst) : m_map{map} {
     if (auto *CI = llvm::dyn_cast<llvm::CallInst>(&inst)) {
       const llvm::Function *callee = CI->getCalledFunction();
-      if (callee) {
-        if (createFromFunc(*callee))
-          return;
-      }
+      if (callee && createFromFunc(*callee))
+        return;
     }
 
     const unsigned op = inst.getOpcode();

--- a/include/llvm-dialects/Dialect/OpMap.h
+++ b/include/llvm-dialects/Dialect/OpMap.h
@@ -595,13 +595,14 @@ template <typename ValueT, bool isConst> class OpMapIteratorBase final {
         if (std::get<BaseIteratorT>(m_iterator) == map->m_intrinsics.end())
           invalidate();
       }
-    } else {
-      createFromDialectOp(desc.getMnemonic());
+    } else if (!createFromDialectOp(desc.getMnemonic())) {
+      invalidate();
     }
   }
 
   OpMapIteratorBase(OpMapT *map, const llvm::Function &func) : m_map{map} {
-    createFromFunc(func);
+    if (!createFromFunc(func))
+      invalidate();
   }
 
   // Do a lookup for a given instruction. Mark the iterator as invalid
@@ -610,18 +611,12 @@ template <typename ValueT, bool isConst> class OpMapIteratorBase final {
     if (auto *CI = llvm::dyn_cast<llvm::CallInst>(&inst)) {
       const llvm::Function *callee = CI->getCalledFunction();
       if (callee) {
-        createFromFunc(*callee);
-        return;
+        if (createFromFunc(*callee))
+          return;
       }
     }
 
     const unsigned op = inst.getOpcode();
-
-    // Construct an invalid iterator.
-    if (op == llvm::Instruction::Call || op == llvm::Instruction::CallBr) {
-      invalidate();
-      return;
-    }
 
     BaseIteratorT it = m_map->m_coreOpcodes.find(op);
     if (it != m_map->m_coreOpcodes.end()) {
@@ -699,20 +694,20 @@ protected:
 private:
   void invalidate() { m_isInvalid = true; }
 
-  void createFromFunc(const llvm::Function &func) {
+  bool createFromFunc(const llvm::Function &func) {
     if (func.isIntrinsic()) {
       m_iterator = m_map->m_intrinsics.find(func.getIntrinsicID());
 
       if (std::get<BaseIteratorT>(m_iterator) != m_map->m_intrinsics.end()) {
         m_desc = OpDescription::fromIntrinsic(func.getIntrinsicID());
-        return;
+        return true;
       }
     }
 
-    createFromDialectOp(func.getName());
+    return createFromDialectOp(func.getName());
   }
 
-  void createFromDialectOp(llvm::StringRef funcName) {
+  bool createFromDialectOp(llvm::StringRef funcName) {
     size_t idx = 0;
     bool found = false;
     for (auto &dialectOpKV : m_map->m_dialectOps) {
@@ -729,8 +724,7 @@ private:
       ++idx;
     }
 
-    if (!found)
-      invalidate();
+    return found;
   }
 
   // Re-construct base OpDescription from the stored iterator.

--- a/test/example/visitor-basic.ll
+++ b/test/example/visitor-basic.ll
@@ -17,6 +17,9 @@
 ; DEFAULT-NEXT:   %q =
 ; DEFAULT-NEXT: visiting umin (set): %vm = call i32 @llvm.umin.i32(i32 %v1, i32 %q) 
 ; DEFAULT-NEXT: visiting StringAttrOp: Hello world!
+; DEFAULT-NEXT: visiting CallInst:   %0 = call i32 @op.func(i32 %v1, i32 %q)
+; DEFAULT-NEXT: visiting CallBrInst:   callbr void @callee()
+; DEFAULT-NEXT: to label %continueBB [label %label1BB, label %label2BB]
 ; DEFAULT-NEXT: visiting Ret (set): ret void
 ; DEFAULT-NEXT: visiting ReturnInst: ret void
 ; DEFAULT-NEXT: inner.counter = 1
@@ -40,9 +43,21 @@ entry:
   call void (...) @xd.ir.write.vararg(i8 %t, i32 %v2, i32 %q)
   %vm = call i32 @llvm.umin.i32(i32 %v1, i32 %q)
   call void @xd.ir.string.attr.op(ptr @0)
+  call i32 @op.func(i32 %v1, i32 %q)
+  callbr void @callee() to label %continueBB [label %label1BB, label %label2BB]
   ret void
+
+continueBB:
+  br label %entry
+
+label1BB:
+  br label %entry
+
+label2BB:
+  br label %entry
 }
 
+declare void @callee()
 declare i32 @xd.ir.read__i32()
 declare i1 @xd.ir.set.read__i1()
 declare i32 @xd.ir.set.read__i32()
@@ -53,3 +68,4 @@ declare i8 @xd.ir.itrunc__i8(...)
 declare void @xd.ir.string.attr.op(ptr)
 declare i32 @llvm.umax.i32(i32, i32)
 declare i32 @llvm.umin.i32(i32, i32)
+declare void @op.func(i32, i32)

--- a/test/unit/interface/OpMapIRTests.cpp
+++ b/test/unit/interface/OpMapIRTests.cpp
@@ -262,7 +262,7 @@ TEST_F(OpMapIRTestFixture, CallCoreOpMatchesInstructionTest) {
   PointerType *PtrTy = B.getPtrTy();
   IntegerType *I32Ty = Type::getInt32Ty(Context);
 
-  // Declare: %ptr @ProcOpaqueHandle(i32, %ptr)
+  // Declare: ptr @ProcOpaqueHandle(i32, ptr)
   FunctionType *ProcOpaqueHandleFuncTy =
       FunctionType::get(PtrTy, {I32Ty, PtrTy}, false);
   FunctionCallee ProcOpaqueHandleFunc =


### PR DESCRIPTION
* We have encountered IR where it is necessary to transform a CallInst.
* This requires a CallInst visitor. Although, a CallInst visitor can be
  added to the OpMap, it fails to find the CallInst visitor. Instead it
  gives up when it determines the Call is not an intrinsic or
  llvm-dialect op.
* This change ensures we can find the CallInst visitor.