### PR TITLE
Argument attributes support

### DIFF
--- a/example/ExampleDialect.td
+++ b/example/ExampleDialect.td
@@ -148,7 +148,7 @@ def Add32Op : ExampleOp<"add32", [Memory<[]>, NoUnwind, WillReturn]> {
   }];
 }
 
-def SizeOfOp : ExampleOp<"sizeof", [Memory<[]>, NoUnwind, WillReturn]> {
+def SizeOfOp : ExampleOp<"sizeof", [Memory<[]>, NoUnwind, WillReturn, NoCapture<ArgIndex<0>>]> {
   let results = (outs I64:$result);
   let arguments = (ins type:$sizeof_type);
 

--- a/include/llvm-dialects/Dialect/Dialect.td
+++ b/include/llvm-dialects/Dialect/Dialect.td
@@ -328,6 +328,10 @@ class LlvmEnumAttributeTrait<string llvmEnum_> : Trait {
   string llvmEnum = llvmEnum_;
 }
 
+class LlvmEnumArgAttributeTrait<string llvmEnum_> : LlvmEnumAttributeTrait<llvmEnum_> {
+  int idx;
+}
+
 def NoUnwind : LlvmEnumAttributeTrait<"NoUnwind">;
 def WillReturn : LlvmEnumAttributeTrait<"WillReturn">;
 def NoReturn : LlvmEnumAttributeTrait<"NoReturn">;
@@ -345,6 +349,14 @@ def Cold : LlvmEnumAttributeTrait<"Cold">;
 def Hot : LlvmEnumAttributeTrait<"Hot">;
 def Convergent : LlvmEnumAttributeTrait<"Convergent">;
 def Speculatable : LlvmEnumAttributeTrait<"Speculatable">;
+
+class ArgIndex<int argNo_> {
+  int argNo = argNo_;
+}
+
+class NoCapture <ArgIndex argIdx> : LlvmEnumArgAttributeTrait<"NoCapture"> {
+  let idx = argIdx.argNo;
+}
 
 /// Represent the LLVM `memory(...)` attribute as the OR (or union) of memory
 /// effects. An empty effects list means the operation does not access memory

--- a/include/llvm-dialects/TableGen/Traits.h
+++ b/include/llvm-dialects/TableGen/Traits.h
@@ -40,6 +40,7 @@ public:
   enum class Kind : uint8_t {
     LlvmAttributeTrait_First,
     LlvmEnumAttributeTrait = LlvmAttributeTrait_First,
+    LlvmEnumArgAttributeTrait,
     LlvmMemoryAttributeTrait,
     LlvmAttributeTrait_Last = LlvmMemoryAttributeTrait,
   };

--- a/lib/TableGen/GenDialect.cpp
+++ b/lib/TableGen/GenDialect.cpp
@@ -343,10 +343,13 @@ void llvm_dialects::genDialectDefs(raw_ostream &out, RecordKeeperTy &records) {
   if (!dialect->attribute_lists_empty()) {
     FmtContextScope scope{fmt};
     fmt.addSubst("attrBuilder", "attrBuilder");
+    fmt.addSubst("argAttrList", "argAttrList");
 
     for (const auto &enumeratedTraits : enumerate(dialect->attribute_lists())) {
       out << tgfmt("{\n  ::llvm::AttrBuilder $attrBuilder{context};\n", &fmt);
+      out << tgfmt("  ::llvm::AttributeList $argAttrList;\n", &fmt);
 
+      SmallVector<const LlvmAttributeTrait *> argTraits;
       for (const Trait *trait : enumeratedTraits.value()) {
         if (auto *llvmAttribute = dyn_cast<LlvmAttributeTrait>(trait)) {
           llvmAttribute->addAttribute(out, fmt);
@@ -355,8 +358,8 @@ void llvm_dialects::genDialectDefs(raw_ostream &out, RecordKeeperTy &records) {
         }
       }
 
-      out << tgfmt("m_attributeLists[$0] = ::llvm::AttributeList::get(context, "
-                   "::llvm::AttributeList::FunctionIndex, $attrBuilder);\n}\n",
+      out << tgfmt("m_attributeLists[$0] = "
+                   "$argAttrList.addFnAttributes(context, $attrBuilder);\n}\n",
                    &fmt, enumeratedTraits.index());
     }
   }

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -1552,7 +1552,7 @@ instName
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(4);
+          = ExampleDialect::get(context).getAttributeList(5);
     auto fnType = ::llvm::FunctionType::get(::llvm::Type::getVoidTy(context), {
 }, false);
 
@@ -1603,7 +1603,7 @@ instName
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(4);
+          = ExampleDialect::get(context).getAttributeList(5);
     auto fnType = ::llvm::FunctionType::get(::llvm::Type::getVoidTy(context), {
 }, false);
 

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -185,35 +185,49 @@ namespace xd::cpp {
     ExampleDialect::ExampleDialect(::llvm::LLVMContext& context) : DialectImpl(context) {
   {
   ::llvm::AttrBuilder attrBuilder{context};
+  ::llvm::AttributeList argAttrList;
 attrBuilder.addAttribute(::llvm::Attribute::NoUnwind);
 attrBuilder.addAttribute(::llvm::Attribute::WillReturn);
 attrBuilder.addMemoryAttr(::llvm::MemoryEffects::none());
-m_attributeLists[0] = ::llvm::AttributeList::get(context, ::llvm::AttributeList::FunctionIndex, attrBuilder);
+m_attributeLists[0] = argAttrList.addFnAttributes(context, attrBuilder);
 }
 {
   ::llvm::AttrBuilder attrBuilder{context};
+  ::llvm::AttributeList argAttrList;
+attrBuilder.addAttribute(::llvm::Attribute::NoUnwind);
+attrBuilder.addAttribute(::llvm::Attribute::WillReturn);
+attrBuilder.addMemoryAttr(::llvm::MemoryEffects::none());
+argAttrList = argAttrList.addParamAttribute(context, 0, ::llvm::Attribute::NoCapture);
+m_attributeLists[1] = argAttrList.addFnAttributes(context, attrBuilder);
+}
+{
+  ::llvm::AttrBuilder attrBuilder{context};
+  ::llvm::AttributeList argAttrList;
 attrBuilder.addAttribute(::llvm::Attribute::NoUnwind);
 attrBuilder.addAttribute(::llvm::Attribute::WillReturn);
 attrBuilder.addMemoryAttr(::llvm::MemoryEffects(::llvm::ModRefInfo::Ref));
-m_attributeLists[1] = ::llvm::AttributeList::get(context, ::llvm::AttributeList::FunctionIndex, attrBuilder);
+m_attributeLists[2] = argAttrList.addFnAttributes(context, attrBuilder);
 }
 {
   ::llvm::AttrBuilder attrBuilder{context};
+  ::llvm::AttributeList argAttrList;
 attrBuilder.addAttribute(::llvm::Attribute::NoUnwind);
 attrBuilder.addAttribute(::llvm::Attribute::WillReturn);
 attrBuilder.addMemoryAttr(::llvm::MemoryEffects(::llvm::MemoryEffects::Location::InaccessibleMem, ::llvm::ModRefInfo::Mod));
-m_attributeLists[2] = ::llvm::AttributeList::get(context, ::llvm::AttributeList::FunctionIndex, attrBuilder);
+m_attributeLists[3] = argAttrList.addFnAttributes(context, attrBuilder);
 }
 {
   ::llvm::AttrBuilder attrBuilder{context};
+  ::llvm::AttributeList argAttrList;
 attrBuilder.addAttribute(::llvm::Attribute::NoUnwind);
 attrBuilder.addMemoryAttr(::llvm::MemoryEffects(::llvm::MemoryEffects::Location::InaccessibleMem, ::llvm::ModRefInfo::ModRef));
-m_attributeLists[3] = ::llvm::AttributeList::get(context, ::llvm::AttributeList::FunctionIndex, attrBuilder);
+m_attributeLists[4] = argAttrList.addFnAttributes(context, attrBuilder);
 }
 {
   ::llvm::AttrBuilder attrBuilder{context};
+  ::llvm::AttributeList argAttrList;
 attrBuilder.addAttribute(::llvm::Attribute::WillReturn);
-m_attributeLists[4] = ::llvm::AttributeList::get(context, ::llvm::AttributeList::FunctionIndex, attrBuilder);
+m_attributeLists[5] = argAttrList.addFnAttributes(context, attrBuilder);
 }
 }
 
@@ -1111,7 +1125,7 @@ source
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(4);
+          = ExampleDialect::get(context).getAttributeList(5);
     auto fnType = ::llvm::FunctionType::get(::llvm::Type::getVoidTy(context), {
 ::llvm::IntegerType::get(context, 1),
 }, false);
@@ -1302,7 +1316,7 @@ index
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(4);
+          = ExampleDialect::get(context).getAttributeList(5);
     auto fnType = ::llvm::FunctionType::get(::llvm::IntegerType::get(context, 32), true);
 
     auto fn = module.getOrInsertFunction(s_name, fnType, attrs);
@@ -1386,7 +1400,7 @@ instName_0
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(4);
+          = ExampleDialect::get(context).getAttributeList(5);
     auto fnType = ::llvm::FunctionType::get(::llvm::IntegerType::get(context, 32), true);
 
     auto fn = module.getOrInsertFunction(s_name, fnType, attrs);
@@ -1460,7 +1474,7 @@ instName
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(4);
+          = ExampleDialect::get(context).getAttributeList(5);
     auto fnType = ::llvm::FunctionType::get(::llvm::IntegerType::get(context, 32), true);
 
     auto fn = module.getOrInsertFunction(s_name, fnType, attrs);
@@ -1640,7 +1654,7 @@ instName
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(3);
+          = ExampleDialect::get(context).getAttributeList(4);
     
       std::string mangledName =
           ::llvm_dialects::getMangledName(s_name, {dataType});
@@ -1697,7 +1711,7 @@ instName
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(3);
+          = ExampleDialect::get(context).getAttributeList(4);
     
       std::string mangledName =
           ::llvm_dialects::getMangledName(s_name, {dataType});
@@ -1754,7 +1768,7 @@ instName
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(2);
+          = ExampleDialect::get(context).getAttributeList(3);
     auto fnType = ::llvm::FunctionType::get(::llvm::Type::getVoidTy(context), true);
 
     auto fn = module.getOrInsertFunction(s_name, fnType, attrs);
@@ -1817,7 +1831,7 @@ data
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(0);
+          = ExampleDialect::get(context).getAttributeList(1);
     auto fnType = ::llvm::FunctionType::get(::llvm::IntegerType::get(context, 64), true);
 
     auto fn = module.getOrInsertFunction(s_name, fnType, attrs);
@@ -1891,7 +1905,7 @@ data
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(1);
+          = ExampleDialect::get(context).getAttributeList(2);
     
       std::string mangledName =
           ::llvm_dialects::getMangledName(s_name, {initial->getType()});
@@ -1983,7 +1997,7 @@ initial
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(1);
+          = ExampleDialect::get(context).getAttributeList(2);
     
       std::string mangledName =
           ::llvm_dialects::getMangledName(s_name, {initial->getType()});
@@ -2075,7 +2089,7 @@ initial
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(1);
+          = ExampleDialect::get(context).getAttributeList(2);
     
       std::string mangledName =
           ::llvm_dialects::getMangledName(s_name, {initial->getType()});
@@ -2167,7 +2181,7 @@ initial
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(4);
+          = ExampleDialect::get(context).getAttributeList(5);
     auto fnType = ::llvm::FunctionType::get(::llvm::Type::getVoidTy(context), {
 ::llvm::PointerType::get(::llvm::Type::getInt8Ty(context), 0),
 }, false);
@@ -2236,7 +2250,7 @@ initial
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(2);
+          = ExampleDialect::get(context).getAttributeList(3);
     auto fnType = ::llvm::FunctionType::get(::llvm::Type::getVoidTy(context), true);
 
     auto fn = module.getOrInsertFunction(s_name, fnType, attrs);
@@ -2299,7 +2313,7 @@ data
   
   
       const ::llvm::AttributeList attrs
-          = ExampleDialect::get(context).getAttributeList(2);
+          = ExampleDialect::get(context).getAttributeList(3);
     auto fnType = ::llvm::FunctionType::get(::llvm::Type::getVoidTy(context), true);
 
     auto fn = module.getOrInsertFunction(s_name, fnType, attrs);

--- a/test/example/generated/ExampleDialect.h.inc
+++ b/test/example/generated/ExampleDialect.h.inc
@@ -47,7 +47,7 @@ namespace xd::cpp {
         }
 
       private:
-        ::std::array<::llvm::AttributeList, 5> m_attributeLists;
+        ::std::array<::llvm::AttributeList, 6> m_attributeLists;
     };
 
     class XdHandleType : public ::llvm::TargetExtType {


### PR DESCRIPTION
It would make sense to be able to mark some ops' arguments as NoCapture, (eg. `BufferLengthOp`).