### PR TITLE
EmitLongStrLiterals cl::opt is now global in upstream LLVM

### DIFF
--- a/utils/llvm-dialects-tblgen.cpp
+++ b/utils/llvm-dialects-tblgen.cpp
@@ -29,6 +29,7 @@
 using namespace llvm_dialects;
 using namespace llvm;
 
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 533951
 namespace llvm {
 cl::opt<bool> EmitLongStrLiterals(
     "long-string-literals",
@@ -37,6 +38,7 @@ cl::opt<bool> EmitLongStrLiterals(
              "compile-time performance win, but upsets some compilers"),
     cl::Hidden, cl::init(true));
 } // end namespace llvm
+#endif // LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 533951
 
 namespace {
 


### PR DESCRIPTION
LLVM upstream change: https://github.com/llvm/llvm-project/pull/124856 makes EmitLongStrLiterals cl::opt global