### PR TITLE
Fix build with shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,6 @@ if (llvm_dialects_is_in_llvm_build_tree)
     add_tablegen(llvm-dialects-tblgen LLVM_DIALECTS
         DESTINATION "${LLVM_TOOLS_INSTALL_DIR}"
         EXPORT LLVM
-        ${LLVM_DIALECTS_TABLEGEN_SOURCES}
     )
     if(CMAKE_CROSSCOMPILING)
         set(LLVM_DIALECTS_TABLEGEN_EXE_HOST "${LLVM_DIALECTS_TABLEGEN_EXE}" CACHE


### PR DESCRIPTION
With `-DBUILD_SHARED_LIBS=ON`, the command line option gets defined twice because the source file is included twice, once as part of the `llvm_dialects_tablegen` library (line 154), once directly in the binary.

Fix this by adding source files only to the library, not to the binary.