### PR TITLE
Fix up warnings

### DIFF
--- a/lib/TableGen/Operations.cpp
+++ b/lib/TableGen/Operations.cpp
@@ -322,7 +322,7 @@ void OperationBase::parseValueTraits(raw_ostream &errs, RecordTy *record,
   }
 
   const ListInit *List = record->getValueAsListInit("value_traits");
-  for (const Init *I : List->getValues()) {
+  for (const Init *I : List->getElements()) {
     if (const DagInit *DI = dyn_cast<DagInit>(I)) {
       if (DI->getNumArgs() != 1) {
         errs << "value_traits " << *DI << " is missing argument name";
@@ -840,7 +840,7 @@ void BuilderMethod::emitDefinition(raw_ostream &out, FmtContext &fmt,
     )",
                  &fmt);
   } else {
-    out << tgfmt("return ::llvm::cast<$_op>($_builder.CreateCall($fn, std::nullopt, $_instname));\n",
+    out << tgfmt("return ::llvm::cast<$_op>($_builder.CreateCall($fn, {}, $_instname));\n",
                  &fmt);
   }
 

--- a/lib/TableGen/Operations.cpp
+++ b/lib/TableGen/Operations.cpp
@@ -322,7 +322,13 @@ void OperationBase::parseValueTraits(raw_ostream &errs, RecordTy *record,
   }
 
   const ListInit *List = record->getValueAsListInit("value_traits");
-  for (const Init *I : List->getElements()) {
+  for (const Init *I : List->
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 538013
+                       getValues()
+#else
+                       getElements()
+#endif
+  ) {
     if (const DagInit *DI = dyn_cast<DagInit>(I)) {
       if (DI->getNumArgs() != 1) {
         errs << "value_traits " << *DI << " is missing argument name";

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -1007,7 +1007,7 @@ source
     assert(fn.getFunctionType() == fnType);
     assert(::llvm::cast<::llvm::Function>(fn.getCallee())->getFunctionType() == fn.getFunctionType());
 
-  return ::llvm::cast<HandleGetOp>(b.CreateCall(fn, std::nullopt, instName));
+  return ::llvm::cast<HandleGetOp>(b.CreateCall(fn, {}, instName));
 }
 
 
@@ -1692,7 +1692,7 @@ instName
     assert(fn.getFunctionType() == fnType);
     assert(::llvm::cast<::llvm::Function>(fn.getCallee())->getFunctionType() == fn.getFunctionType());
 
-  return ::llvm::cast<NoDescriptionOp>(b.CreateCall(fn, std::nullopt, instName));
+  return ::llvm::cast<NoDescriptionOp>(b.CreateCall(fn, {}, instName));
 }
 
 
@@ -1743,7 +1743,7 @@ instName
     assert(fn.getFunctionType() == fnType);
     assert(::llvm::cast<::llvm::Function>(fn.getCallee())->getFunctionType() == fn.getFunctionType());
 
-  return ::llvm::cast<NoSummaryOp>(b.CreateCall(fn, std::nullopt, instName));
+  return ::llvm::cast<NoSummaryOp>(b.CreateCall(fn, {}, instName));
 }
 
 
@@ -1797,7 +1797,7 @@ instName
     assert(fn.getFunctionType() == fnType);
     assert(::llvm::cast<::llvm::Function>(fn.getCallee())->getFunctionType() == fn.getFunctionType());
 
-  return ::llvm::cast<ReadOp>(b.CreateCall(fn, std::nullopt, instName));
+  return ::llvm::cast<ReadOp>(b.CreateCall(fn, {}, instName));
 }
 
 
@@ -1854,7 +1854,7 @@ instName
     assert(fn.getFunctionType() == fnType);
     assert(::llvm::cast<::llvm::Function>(fn.getCallee())->getFunctionType() == fn.getFunctionType());
 
-  return ::llvm::cast<SetReadOp>(b.CreateCall(fn, std::nullopt, instName));
+  return ::llvm::cast<SetReadOp>(b.CreateCall(fn, {}, instName));
 }
 
 


### PR DESCRIPTION
Change use of ArrayRef into {}
Change deprecated getValues into getElements