### PR TITLE
Do not add null byte for immutable strings

### DIFF
--- a/include/llvm-dialects/Dialect/Dialect.td
+++ b/include/llvm-dialects/Dialect/Dialect.td
@@ -296,7 +296,7 @@ def : AttrLlvmType<AttrI32, I32>;
 def : AttrLlvmType<AttrI64, I64>;
 
 def ImmutableStringAttr : Attr<"::llvm::StringRef"> {
-  let toLlvmValue = [{ $_builder.CreateGlobalString($0, "str") }];
+  let toLlvmValue = [{ $_builder.CreateGlobalString($0, "str", 0, nullptr, /* AddNull */ false) }];
   let fromLlvmValue = [{ ::llvm::cast<::llvm::ConstantDataArray>(::llvm::cast<::llvm::GlobalVariable>($0)->getInitializer())->getAsString() }];
   let isImmutable = true;
 }

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -2543,7 +2543,7 @@ initial
 
   
 ::llvm::SmallVector<::llvm::Value*, 1> args = {
- b.CreateGlobalString(val, "str") 
+ b.CreateGlobalString(val, "str", 0, nullptr, /* AddNull */ false) 
       };
       
       return ::llvm::cast<StringAttrOp>(b.CreateCall(fn, args, instName));

--- a/test/example/test-builder.test
+++ b/test/example/test-builder.test
@@ -22,7 +22,7 @@
 ; RUN: llvm-dialects-example - | FileCheck --check-prefixes=CHECK %s
 
 ;.
-; CHECK: @str = private unnamed_addr constant [13 x i8] c"Hello world!\00", align 1
+; CHECK: @str = private unnamed_addr constant [12 x i8] c"Hello world!", align 1
 ;.
 ; CHECK-LABEL: define void @example() {
 ; CHECK-NEXT:  [[ENTRY:.*:]]

--- a/test/example/visitor-basic.ll
+++ b/test/example/visitor-basic.ll
@@ -43,7 +43,7 @@
 ; DEFAULT-NEXT: visiting ReturnInst: ret void
 ; DEFAULT-NEXT: inner.counter = 1
 
-@0 = private unnamed_addr constant [13 x i8] c"Hello world!\00", align 1
+@0 = private unnamed_addr constant [12 x i8] c"Hello world!", align 1
 
 define void @test1(ptr %p) {
 entry:


### PR DESCRIPTION
`CreateGlobalString` will add a null byte to the end of string by default, which prevents us from getting the exact same string back as we set.

This makes it hard to use for cases where we need exact string matching, such as function names lookup.