### PR TITLE
Update tests to not use Br instruction

### DIFF
--- a/test/unit/interface/OpMapTests.cpp
+++ b/test/unit/interface/OpMapTests.cpp
@@ -34,17 +34,17 @@ TEST(OpMapBasicTestsName, CoreOpContainsTests) {
   OpMap<StringRef> map;
 
   OpDescription retDesc = OpDescription::fromCoreOp(Instruction::Ret);
-  OpDescription brDesc = OpDescription::fromCoreOp(Instruction::Br);
+  OpDescription callBrDesc = OpDescription::fromCoreOp(Instruction::CallBr);
   map[retDesc] = "RetInst";
 
   EXPECT_TRUE(map.containsCoreOp(Instruction::Ret));
-  EXPECT_FALSE(map.containsCoreOp(Instruction::Br));
+  EXPECT_FALSE(map.containsCoreOp(Instruction::CallBr));
   EXPECT_EQ(map[retDesc], "RetInst");
 
-  map[brDesc] = "BrInst";
+  map[callBrDesc] = "CallBrInst";
   EXPECT_EQ(map[retDesc], "RetInst");
-  EXPECT_TRUE(map.containsCoreOp(Instruction::Br));
-  EXPECT_EQ(map[brDesc], "BrInst");
+  EXPECT_TRUE(map.containsCoreOp(Instruction::CallBr));
+  EXPECT_EQ(map[callBrDesc], "CallBrInst");
 }
 
 TEST(OpMapBasicTestsName, IntrinsicOpContainsTests) {

--- a/test/unit/interface/OpSetTests.cpp
+++ b/test/unit/interface/OpSetTests.cpp
@@ -65,9 +65,9 @@ TEST(DialectsOpSetSizeTestsName, NonEmptyOpDescriptionsTemplatizedMakerTest) {
 }
 
 TEST(DialectsOpSetContainsTestsName, containsCoreOps) {
-  const OpSet set = OpSet::fromCoreOpcodes({1, 2}); // Ret, Br
+  const OpSet set = OpSet::fromCoreOpcodes({Instruction::Ret, Instruction::CallBr});
   EXPECT_TRUE(set.containsCoreOp(Instruction::Ret));
-  EXPECT_TRUE(set.containsCoreOp(Instruction::Br));
+  EXPECT_TRUE(set.containsCoreOp(Instruction::CallBr));
   EXPECT_FALSE(set.containsCoreOp(Instruction::Switch));
 }
 


### PR DESCRIPTION
Upstream LLVM split Br into CondBr/UncondBr
https://github.com/llvm/llvm-project/pull/184027