### PR TITLE
Add support for visiting op classes

### DIFF
--- a/include/llvm-dialects/Dialect/OpDescription.h
+++ b/include/llvm-dialects/Dialect/OpDescription.h
@@ -65,7 +65,13 @@ public:
     return m_kind == Kind::Dialect || m_kind == Kind::DialectWithOverloads;
   }
 
+  // Only supported for concrete ops, not for op classes.
   template <typename OpT> static const OpDescription &get();
+
+  // For concrete ops, returns a 1-element array containing the result of get().
+  // For op classes, returns an array containing the descriptions of all
+  // concrete ops that belong to this op class.
+  template <typename OpT> static llvm::ArrayRef<OpDescription> getAll();
 
   Kind getKind() const { return m_kind; }
 

--- a/include/llvm-dialects/Dialect/Visitor.h
+++ b/include/llvm-dialects/Dialect/Visitor.h
@@ -120,9 +120,18 @@ class VisitorKey {
   friend class VisitorTemplate;
 
 public:
+  // OpT may be a concrete dialect op, or an op class.
   template <typename OpT> static VisitorKey op() {
-    VisitorKey key{Kind::OpDescription};
-    key.m_description = &OpDescription::get<OpT>();
+    auto const descriptions = OpDescription::getAll<OpT>();
+    if (descriptions.size() == 1) {
+      VisitorKey key{Kind::OpDescription};
+      key.m_description = &descriptions[0];
+      return key;
+    }
+    // OpT is an op class. Resolve it by all concrete sub ops.
+    static const OpSet set = OpSet::fromOpDescriptions(descriptions);
+    VisitorKey key{Kind::OpSet};
+    key.m_set = &set;
     return key;
   }
 

--- a/lib/Dialect/OpDescription.cpp
+++ b/lib/Dialect/OpDescription.cpp
@@ -112,6 +112,10 @@ template <> const OpDescription &OpDescription::get<UnaryInstruction>() {
   return desc;
 }
 
+template <> ArrayRef<OpDescription> OpDescription::getAll<UnaryInstruction>() {
+  return get<UnaryInstruction>();
+}
+
 template <> const OpDescription &OpDescription::get<BinaryOperator>() {
   static unsigned opcodes[] = {
 #define HANDLE_BINARY_INST(num, opcode, Class) Instruction::opcode,
@@ -119,6 +123,10 @@ template <> const OpDescription &OpDescription::get<BinaryOperator>() {
   };
   static const OpDescription desc{Kind::Core, opcodes};
   return desc;
+}
+
+template <> ArrayRef<OpDescription> OpDescription::getAll<BinaryOperator>() {
+  return get<BinaryOperator>();
 }
 
 // Generate OpDescription for all dedicate instruction classes.
@@ -129,6 +137,9 @@ template <> const OpDescription &OpDescription::get<BinaryOperator>() {
   template <> const OpDescription &OpDescription::get<Class>() {               \
     static const OpDescription desc{Kind::Core, Instruction::opcode};          \
     return desc;                                                               \
+  }                                                                            \
+  template <> ArrayRef<OpDescription> OpDescription::getAll<Class>() {         \
+    return get<Class>();                                                       \
   }
 #include "llvm/IR/Instruction.def"
 
@@ -136,12 +147,18 @@ template <> const OpDescription &OpDescription::get<BinaryOperator>() {
   template <> const OpDescription &OpDescription::get<Class>() {               \
     static const OpDescription desc{Kind::Intrinsic, Intrinsic::opcode};       \
     return desc;                                                               \
+  }                                                                            \
+  template <> ArrayRef<OpDescription> OpDescription::getAll<Class>() {         \
+    return get<Class>();                                                       \
   }
 #define HANDLE_INTRINSIC_DESC_OPCODE_SET(Class, ...)                           \
   template <> const OpDescription &OpDescription::get<Class>() {               \
     static unsigned opcodes[] = {__VA_ARGS__};                                 \
     static const OpDescription desc{Kind::Intrinsic, opcodes};                 \
     return desc;                                                               \
+  }                                                                            \
+  template <> ArrayRef<OpDescription> OpDescription::getAll<Class>() {         \
+    return get<Class>();                                                       \
   }
 
 // ============================================================================

--- a/lib/TableGen/GenDialect.cpp
+++ b/lib/TableGen/GenDialect.cpp
@@ -271,6 +271,7 @@ void llvm_dialects::genDialectDefs(raw_ostream &out, RecordKeeperTy &records) {
 
   out << R"(
 #include "llvm/Support/raw_ostream.h"
+#include <array>
 #endif // GET_INCLUDES
 
 #ifdef GET_DIALECT_DEFS
@@ -326,10 +327,10 @@ void llvm_dialects::genDialectDefs(raw_ostream &out, RecordKeeperTy &records) {
     }
 
     bool $Dialect::isDialectOp(::llvm::CallInst& op) {
-      ::llvm::Function *calledFunc = op.getCalledFunction(); 
+      ::llvm::Function *calledFunc = op.getCalledFunction();
       if (!calledFunc)
         return false;
-      
+
       return isDialectOp(calledFunc->getName());
     }
 
@@ -448,7 +449,7 @@ void llvm_dialects::genDialectDefs(raw_ostream &out, RecordKeeperTy &records) {
   if (!dialect->cppNamespace.empty())
     out << tgfmt("} // namespace $namespace\n", &fmt);
 
-  // Define specializations of OpDescription::get for reflection
+  // Define specializations of OpDescription::{get, getAll} for reflection
   for (const auto &opPtr : dialect->operations) {
     Operation &op = *opPtr;
 
@@ -456,6 +457,10 @@ void llvm_dialects::genDialectDefs(raw_ostream &out, RecordKeeperTy &records) {
     fmt.withOp(op.name);
     fmt.addSubst("mnemonic", op.mnemonic);
 
+    // We'd prefer fully qualifying the llvm_dialects namespace below in getAll
+    // with leading "::", but this is parsed as oart of the preceding ArrayRef
+    // type as there are just spaces in between. (gcc/clang/MSVC reject this)
+    // The get() variant does not have this problem due to the `&` token.
     out << tgfmt(R"(
       template <>
       const ::llvm_dialects::OpDescription &
@@ -464,8 +469,46 @@ void llvm_dialects::genDialectDefs(raw_ostream &out, RecordKeeperTy &records) {
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<$namespace::$_op>() {
+        return get<$namespace::$_op>();
+      }
+
     )",
                  &fmt, op.haveResultOverloads() ? "true" : "false");
+  }
+
+  // Define specializations of OpDescription::getAll for op classes
+  for (const auto &opClassPtr : dialect->opClasses) {
+    OpClass &opClass = *opClassPtr;
+
+    FmtContextScope scope{fmt};
+    fmt.withOp(opClass.name);
+
+    // We'd prefer fully qualifying the llvm_dialects namespace below with
+    // leading "::", but gcc/clang/MSVC reject this as they interpret the
+    // ::llvm_dialects identifier than within the preceding ArrayRef type. The
+    // get() variant does not have this problem as the `&` token separates the
+    // two.
+    out << tgfmt(R"(
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<$namespace::$_op>() {
+        static const std::array<::llvm_dialects::OpDescription, $0> desc{)",
+                 &fmt, opClass.operations.size());
+    for (const auto &op : opClass.operations) {
+      fmt.addSubst("mnemonic", op->mnemonic);
+      out << tgfmt(R"(
+          ::llvm_dialects::OpDescription{$0, "$dialect.$mnemonic"},)",
+                   &fmt, op->haveResultOverloads() ? "true" : "false");
+    }
+    out << tgfmt(R"(
+        };
+        return desc;
+      }
+    )",
+                 &fmt, opClass.operations.size());
   }
 
   out << R"(

--- a/test/example/generated/ExampleDialect.cpp.inc
+++ b/test/example/generated/ExampleDialect.cpp.inc
@@ -19,6 +19,7 @@
 #include "llvm/Support/ModRef.h"
 
 #include "llvm/Support/raw_ostream.h"
+#include <array>
 #endif // GET_INCLUDES
 
 #ifdef GET_DIALECT_DEFS
@@ -33,10 +34,10 @@ namespace xd::cpp {
     }
 
     bool ExampleDialect::isDialectOp(::llvm::CallInst& op) {
-      ::llvm::Function *calledFunc = op.getCalledFunction(); 
+      ::llvm::Function *calledFunc = op.getCalledFunction();
       if (!calledFunc)
         return false;
-      
+
       return isDialectOp(calledFunc->getName());
     }
 
@@ -2733,12 +2734,24 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::Add32Op>() {
+        return get<xd::cpp::Add32Op>();
+      }
+
     
       template <>
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::cpp::BufferCompareOp>() {
         static const ::llvm_dialects::OpDescription desc{false, "xd.ir.buffer.compare.op"};
         return desc;
+      }
+
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::BufferCompareOp>() {
+        return get<xd::cpp::BufferCompareOp>();
       }
 
     
@@ -2749,12 +2762,24 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::CombineOp>() {
+        return get<xd::cpp::CombineOp>();
+      }
+
     
       template <>
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::cpp::DummyStructBackedInpOp>() {
         static const ::llvm_dialects::OpDescription desc{false, "xd.ir.struct.backed.inp.op"};
         return desc;
+      }
+
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::DummyStructBackedInpOp>() {
+        return get<xd::cpp::DummyStructBackedInpOp>();
       }
 
     
@@ -2765,12 +2790,24 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::DummyStructBackedOutpOp>() {
+        return get<xd::cpp::DummyStructBackedOutpOp>();
+      }
+
     
       template <>
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::cpp::ExtractElementOp>() {
         static const ::llvm_dialects::OpDescription desc{true, "xd.ir.extractelement"};
         return desc;
+      }
+
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::ExtractElementOp>() {
+        return get<xd::cpp::ExtractElementOp>();
       }
 
     
@@ -2781,12 +2818,24 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::FromFixedVectorOp>() {
+        return get<xd::cpp::FromFixedVectorOp>();
+      }
+
     
       template <>
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::cpp::HandleGetOp>() {
         static const ::llvm_dialects::OpDescription desc{false, "xd.ir.handle.get"};
         return desc;
+      }
+
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::HandleGetOp>() {
+        return get<xd::cpp::HandleGetOp>();
       }
 
     
@@ -2797,12 +2846,24 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::IExtOp>() {
+        return get<xd::cpp::IExtOp>();
+      }
+
     
       template <>
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::cpp::ITruncOp>() {
         static const ::llvm_dialects::OpDescription desc{true, "xd.ir.itrunc"};
         return desc;
+      }
+
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::ITruncOp>() {
+        return get<xd::cpp::ITruncOp>();
       }
 
     
@@ -2813,12 +2874,24 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::ImmutableOp>() {
+        return get<xd::cpp::ImmutableOp>();
+      }
+
     
       template <>
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::cpp::InsertElementOp>() {
         static const ::llvm_dialects::OpDescription desc{true, "xd.ir.insertelement"};
         return desc;
+      }
+
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::InsertElementOp>() {
+        return get<xd::cpp::InsertElementOp>();
       }
 
     
@@ -2829,12 +2902,24 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::InstNameConflictDoubleOp>() {
+        return get<xd::cpp::InstNameConflictDoubleOp>();
+      }
+
     
       template <>
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::cpp::InstNameConflictOp>() {
         static const ::llvm_dialects::OpDescription desc{false, "xd.ir.inst.name.conflict"};
         return desc;
+      }
+
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::InstNameConflictOp>() {
+        return get<xd::cpp::InstNameConflictOp>();
       }
 
     
@@ -2845,12 +2930,24 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::InstNameConflictVarargsOp>() {
+        return get<xd::cpp::InstNameConflictVarargsOp>();
+      }
+
     
       template <>
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::cpp::NoDescriptionOp>() {
         static const ::llvm_dialects::OpDescription desc{false, "xd.ir.no.description.op"};
         return desc;
+      }
+
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::NoDescriptionOp>() {
+        return get<xd::cpp::NoDescriptionOp>();
       }
 
     
@@ -2861,12 +2958,24 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::NoSummaryOp>() {
+        return get<xd::cpp::NoSummaryOp>();
+      }
+
     
       template <>
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::cpp::ReadOp>() {
         static const ::llvm_dialects::OpDescription desc{true, "xd.ir.read"};
         return desc;
+      }
+
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::ReadOp>() {
+        return get<xd::cpp::ReadOp>();
       }
 
     
@@ -2877,12 +2986,24 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::SetReadOp>() {
+        return get<xd::cpp::SetReadOp>();
+      }
+
     
       template <>
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::cpp::SetWriteOp>() {
         static const ::llvm_dialects::OpDescription desc{false, "xd.ir.set.write"};
         return desc;
+      }
+
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::SetWriteOp>() {
+        return get<xd::cpp::SetWriteOp>();
       }
 
     
@@ -2893,12 +3014,24 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::SizeOfOp>() {
+        return get<xd::cpp::SizeOfOp>();
+      }
+
     
       template <>
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::cpp::StreamAddOp>() {
         static const ::llvm_dialects::OpDescription desc{true, "xd.ir.stream.add"};
         return desc;
+      }
+
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::StreamAddOp>() {
+        return get<xd::cpp::StreamAddOp>();
       }
 
     
@@ -2909,12 +3042,24 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::StreamMaxOp>() {
+        return get<xd::cpp::StreamMaxOp>();
+      }
+
     
       template <>
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::cpp::StreamMinOp>() {
         static const ::llvm_dialects::OpDescription desc{true, "xd.ir.stream.min"};
         return desc;
+      }
+
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::StreamMinOp>() {
+        return get<xd::cpp::StreamMinOp>();
       }
 
     
@@ -2925,12 +3070,24 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::StringAttrOp>() {
+        return get<xd::cpp::StringAttrOp>();
+      }
+
     
       template <>
       const ::llvm_dialects::OpDescription &
       ::llvm_dialects::OpDescription::get<xd::cpp::WriteOp>() {
         static const ::llvm_dialects::OpDescription desc{false, "xd.ir.write"};
         return desc;
+      }
+
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::WriteOp>() {
+        return get<xd::cpp::WriteOp>();
       }
 
     
@@ -2941,5 +3098,22 @@ data
         return desc;
       }
 
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::WriteVarArgOp>() {
+        return get<xd::cpp::WriteVarArgOp>();
+      }
+
+    
+      template <>
+      ::llvm::ArrayRef<::llvm_dialects::OpDescription>
+      llvm_dialects::OpDescription::getAll<xd::cpp::StreamReduceOp>() {
+        static const std::array<::llvm_dialects::OpDescription, 3> desc{
+          ::llvm_dialects::OpDescription{true, "xd.ir.stream.add"},
+          ::llvm_dialects::OpDescription{true, "xd.ir.stream.max"},
+          ::llvm_dialects::OpDescription{true, "xd.ir.stream.min"},
+        };
+        return desc;
+      }
     
 #endif // GET_DIALECT_DEFS

--- a/test/unit/dialect/TestDialect.td
+++ b/test/unit/dialect/TestDialect.td
@@ -135,3 +135,26 @@ def DefaultNameTargetExtType : DialectType<TestDialect, "default.target"> {
     Type name should be "test.default.target".
   }];
 }
+
+def SomeBaseOpClass : OpClass<TestDialect> {
+  let arguments = (ins);
+  let summary = "family of operations";
+  let description = [{
+    Illustrate the use of the OpClass feature.
+  }];
+}
+
+class ConcreteOpClassMemberOp<string op>
+    : TestOp<"some.op.class.subop." # op, []> {
+  let superclass = SomeBaseOpClass;
+  let results = (outs);
+  let arguments = (ins superclass);
+
+  let summary = "perform the " # op # " operation";
+  let description = [{
+    Illustrate the use of the OpClass feature.
+  }];
+}
+
+def AddOp : ConcreteOpClassMemberOp<"add">;
+def MulOp : ConcreteOpClassMemberOp<"mul">;

--- a/test/unit/interface/CMakeLists.txt
+++ b/test/unit/interface/CMakeLists.txt
@@ -21,6 +21,7 @@ add_dialects_unit_test(DialectsADTTests
     OpSetTests.cpp
     OpMapTests.cpp
     OpMapIRTests.cpp
-    DialectTypeTests.cpp)
+    DialectTypeTests.cpp
+    VisitorIRTests.cpp)
 
 add_dependencies(DialectsADTTests TestDialectTableGen)

--- a/test/unit/interface/VisitorIRTests.cpp
+++ b/test/unit/interface/VisitorIRTests.cpp
@@ -85,3 +85,26 @@ TEST_F(VisitorIRTestFixture, VisitOp) {
     EXPECT_TRUE(Op == Mul1 || Op == Mul2);
   }
 }
+
+TEST_F(VisitorIRTestFixture, VisitOpClass) {
+  llvm_dialects::Builder Builder{Context};
+  Builder.SetInsertPoint(getEntryBlock());
+
+  auto *Mul1 = Builder.create<test::MulOp>();
+  auto *Mul2 = Builder.create<test::MulOp>();
+  auto *Add1 = Builder.create<test::AddOp>();
+  auto *Add2 = Builder.create<test::AddOp>();
+  auto *DialectOp1 = Builder.create<test::DialectOp1>();
+
+  DenseSet<test::SomeBaseOpClass *> Ops;
+  static const auto Visitor =
+      llvm_dialects::VisitorBuilder<DenseSet<test::SomeBaseOpClass *>>()
+          .add<test::SomeBaseOpClass>(
+              [](auto &Ops, test::SomeBaseOpClass &Op) { Ops.insert(&Op); })
+          .build();
+  Visitor.visit(Ops, *Mod);
+  EXPECT_EQ(Ops.size(), 4);
+  for (const auto *Op : Ops) {
+    EXPECT_TRUE(Op == Mul1 || Op == Mul2 || Op == Add1 || Op == Add2);
+  }
+}

--- a/test/unit/interface/VisitorIRTests.cpp
+++ b/test/unit/interface/VisitorIRTests.cpp
@@ -1,0 +1,87 @@
+/*
+ ***********************************************************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***********************************************************************************************************************
+ */
+
+#include "TestDialect.h"
+#include "llvm-dialects/Dialect/Builder.h"
+#include "llvm-dialects/Dialect/Dialect.h"
+#include "llvm-dialects/Dialect/Visitor.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/Module.h"
+#include "gtest/gtest.h"
+
+#include <memory>
+
+using namespace llvm;
+using namespace llvm_dialects;
+
+class VisitorIRTestFixture : public testing::Test {
+protected:
+  void SetUp() override {
+    setupDialectsContext();
+    makeModule();
+  }
+
+  LLVMContext Context;
+  std::unique_ptr<DialectContext> DC;
+  std::unique_ptr<Module> Mod;
+  Function *EP = nullptr;
+
+  BasicBlock *getEntryBlock() { return EntryBlock; }
+
+private:
+  BasicBlock *EntryBlock = nullptr;
+
+  void makeModule() {
+    Mod = std::make_unique<Module>("dialects_test", Context);
+    const std::array<Type *, 1> Args = {Type::getInt32Ty(Mod->getContext())};
+    FunctionCallee FC = Mod->getOrInsertFunction(
+        "main",
+        FunctionType::get(Type::getVoidTy(Mod->getContext()), Args, false));
+    EP = cast<Function>(FC.getCallee());
+    EntryBlock = BasicBlock::Create(Mod->getContext(), "entry", EP);
+  }
+
+  void setupDialectsContext() {
+    DC = DialectContext::make<test::TestDialect>(Context);
+  }
+};
+
+TEST_F(VisitorIRTestFixture, VisitOp) {
+  llvm_dialects::Builder Builder{Context};
+  Builder.SetInsertPoint(getEntryBlock());
+
+  auto *Mul1 = Builder.create<test::MulOp>();
+  auto *Mul2 = Builder.create<test::MulOp>();
+  auto *Add1 = Builder.create<test::AddOp>();
+  auto *Add2 = Builder.create<test::AddOp>();
+  auto *DialectOp1 = Builder.create<test::DialectOp1>();
+
+  DenseSet<test::MulOp *> Ops;
+  static const auto Visitor =
+      llvm_dialects::VisitorBuilder<DenseSet<test::MulOp *>>()
+          .add<test::MulOp>([](auto &Ops, test::MulOp &Op) { Ops.insert(&Op); })
+          .build();
+  Visitor.visit(Ops, *Mod);
+  EXPECT_EQ(Ops.size(), 2);
+  for (const auto *Op : Ops) {
+    EXPECT_TRUE(Op == Mul1 || Op == Mul2);
+  }
+}


### PR DESCRIPTION
Op classes are sets of ops, providing a common base class in the op class hierarchy,
which can be used to group sets of ops with a common property.

Before this patch, op class only support `isa<>` checks, but not visiting.

This was because visiting relies on `OpDescription::get<OpT>`, which is only supported
for concrete ops, but not op classes.

This patch changes that by introducing a new `OpDescription::getAll<OpT>` template
which returns an `ArrayRef` of OpDescriptions. The existing `get<OpT>` template
is implemented in terms of the new `getAll` template.

Visitor code is changed to use `getAll` instead, and handle non-trivial array refs
(representing op classes) accordingly, using the already existing mechanism for op sets.

I wondered whether it would be better to remove the existing `get` method and migrate everything to the new `getAll` method (and renaming it back to `get`). However, that would require to add support for op classes in all places that rely on `OpDescription`s and `get`, which is more than just visitors. Thus I chose to add a new method for this.

Also, we could instead provide a generic implementation of `get` in terms of `getAll`, because all implementations of `get` are the same: They return `getAll()[0]`. However, that would also add such methods for op classes, which we don't want. We could `assert` that the length is one, but that turns a link-time error into a debug-only assertion failure, which is strictly worse. Maybe we could add some more traits that allow to detect op classes, but I didn't want to complicate things further.