### PR TITLE
Fix for LLVM format_adapter -> FormatFunctorRef

### DIFF
--- a/include/llvm-dialects/TableGen/Format.h
+++ b/include/llvm-dialects/TableGen/Format.h
@@ -187,6 +187,16 @@ protected:
   // indexing capabilities.  In order to enable runtime indexing, we use this
   // structure to put the parameters into a std::vector.  Since the parameters
   // are not all the same type, we use some type-erasure by wrapping the
+#if !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
+  // parameters in a template class and refer to them using function_refs.
+  struct CreateAdapters {
+    template <typename... Ts>
+    std::vector<llvm::support::detail::FormatFunctorRef>
+    operator()(Ts &... items) {
+      return std::vector<llvm::support::detail::FormatFunctorRef>{items...};
+    }
+  };
+#else // !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
   // parameters in a template class that derives from a non-template superclass.
   // Essentially, we are converting a std::tuple<Derived<Ts...>> to a
   // std::vector<Base*>.
@@ -197,10 +207,15 @@ protected:
       return std::vector<llvm::support::detail::format_adapter *>{&items...};
     }
   };
+#endif // LLVM_MAIN_REVISION
 
   llvm::StringRef fmt;
   const FmtContext *context;
+#if !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
+  std::vector<llvm::support::detail::FormatFunctorRef> adapters;
+#else // !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
   std::vector<llvm::support::detail::format_adapter *> adapters;
+#endif // LLVM_MAIN_REVISION
   std::vector<FmtReplacement> replacements;
 
 public:
@@ -260,8 +275,13 @@ public:
 
 class FmtStrVecObject : public FmtObjectBase {
 public:
+#if !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
+  using StrFormatAdapter = decltype(
+      llvm::support::detail::FormatFunctor(std::declval<std::string>()));
+#else // !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
   using StrFormatAdapter = decltype(
       llvm::support::detail::build_format_adapter(std::declval<std::string>()));
+#endif // LLVM_MAIN_REVISION
 
   FmtStrVecObject(llvm::StringRef fmt, const FmtContext *ctx,
                   llvm::ArrayRef<std::string> params);
@@ -318,6 +338,20 @@ private:
 ///    because '{' and '}' are frequently used in C++ code.
 /// 2. This utility does not support format layout because it is rarely needed
 ///    in C++ code generation.
+#if !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
+template <typename... Ts>
+inline auto tgfmt(llvm::StringRef fmt, const FmtContext *ctx, Ts &&... vals)
+    -> FmtObject<
+        decltype(std::make_tuple(llvm::support::detail::FormatFunctor(
+            std::forward<Ts>(vals))...))> {
+  using ParamTuple = decltype(std::make_tuple(
+      llvm::support::detail::FormatFunctor(std::forward<Ts>(vals))...));
+  return FmtObject<ParamTuple>(
+      fmt, ctx,
+      std::make_tuple(llvm::support::detail::FormatFunctor(
+          std::forward<Ts>(vals))...));
+}
+#else // !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
 template <typename... Ts>
 inline auto tgfmt(llvm::StringRef fmt, const FmtContext *ctx, Ts &&... vals)
     -> FmtObject<
@@ -330,6 +364,7 @@ inline auto tgfmt(llvm::StringRef fmt, const FmtContext *ctx, Ts &&... vals)
       std::make_tuple(llvm::support::detail::build_format_adapter(
           std::forward<Ts>(vals))...));
 }
+#endif // LLVM_MAIN_REVISION
 
 inline FmtStrVecObject tgfmt(llvm::StringRef fmt, const FmtContext *ctx,
                              llvm::ArrayRef<std::string> params) {

--- a/lib/TableGen/Format.cpp
+++ b/lib/TableGen/Format.cpp
@@ -218,10 +218,17 @@ void FmtObjectBase::format(raw_ostream &s) const {
         s << repl.spec << kMarkerForNoSubst;
         continue;
       }
+#if !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
+      auto range = ArrayRef<llvm::support::detail::FormatFunctorRef>(adapters);
+      range = range.drop_front(repl.index);
+      llvm::interleaveComma(range, s,
+                            [&](auto &x) { x(s, /*Options=*/""); });
+#else // !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
       auto range = ArrayRef<llvm::support::detail::format_adapter *>(adapters);
       range = range.drop_front(repl.index);
       llvm::interleaveComma(range, s,
                             [&](auto &x) { x->format(s, /*Options=*/""); });
+#endif // LLVM_MAIN_REVISION
       continue;
     }
 
@@ -233,7 +240,11 @@ void FmtObjectBase::format(raw_ostream &s) const {
     if (repl.type == FmtReplacement::Type::IndirectSpecialPH) {
       std::string indirectSpec;
       raw_string_ostream indirectSpecStream(indirectSpec);
+#if !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
+      adapters[repl.index](indirectSpecStream, /*Options=*/"");
+#else // !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
       adapters[repl.index]->format(indirectSpecStream, /*Options=*/"");
+#endif // LLVM_MAIN_REVISION
 
       auto subst = context->getSubstFor(indirectSpec);
       if (subst.has_value())
@@ -245,7 +256,11 @@ void FmtObjectBase::format(raw_ostream &s) const {
 
     assert(repl.type == FmtReplacement::Type::PositionalPH);
 
+#if !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
+    adapters[repl.index](s, /*Options=*/"");
+#else // !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
     adapters[repl.index]->format(s, /*Options=*/"");
+#endif // LLVM_MAIN_REVISION
   }
 }
 
@@ -253,18 +268,34 @@ FmtStrVecObject::FmtStrVecObject(StringRef fmt, const FmtContext *ctx,
                                  ArrayRef<std::string> params)
     : FmtObjectBase(fmt, ctx, params.size()) {
   parameters.reserve(params.size());
+#if !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
   for (std::string p : params)
     parameters.push_back(
+        llvm::support::detail::FormatFunctor(std::move(p)));
+#else // !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
+  for (std::string p : params)
+     parameters.push_back(
         llvm::support::detail::build_format_adapter(std::move(p)));
+#endif // LLVM_MAIN_REVISION
 
   adapters.reserve(parameters.size());
+#if !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
+  for (auto &p : parameters)
+    adapters.push_back(p);
+#else // !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
   for (auto &p : parameters)
     adapters.push_back(&p);
+#endif // LLVM_MAIN_REVISION
 }
 
 FmtStrVecObject::FmtStrVecObject(FmtStrVecObject &&that)
     : FmtObjectBase(std::move(that)), parameters(std::move(that.parameters)) {
   adapters.reserve(parameters.size());
+#if !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
+  for (auto &p : parameters)
+    adapters.push_back(p);
+#else // !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 586890
   for (auto &p : parameters)
     adapters.push_back(&p);
+#endif // LLVM_MAIN_REVISION
 }


### PR DESCRIPTION
Required from LLVM
3aec6a40bb4e [Support] Remove virtual functions from formatv (#207516) but keeping support for earlier LLVM.